### PR TITLE
refactor: change page no from param to query

### DIFF
--- a/src/components/Pagination.vue
+++ b/src/components/Pagination.vue
@@ -2,11 +2,11 @@
   <nav class="pagination">
     <ol class="pagination__list">
       <li class="pagination__item">
-        <router-link v-if="currentPage !== 1" :to="{ name: baseRoute, params: { page: 1, address }}">First</router-link>
+        <router-link v-if="currentPage !== 1" :to="{ name: baseRoute, params: { address }, query: { [queryKey]: 1 }}">First</router-link>
         <span class="not-link" v-else>First</span>
       </li>
       <li class="pagination__item">
-        <router-link v-if="currentPage !== 1" :to="{ name: baseRoute, params: { page: currentPage - 1, address }}">
+        <router-link v-if="currentPage !== 1" :to="{ name: baseRoute, params: { address }, query: { [queryKey]: currentPage - 1 }}">
           <ChevronLeftIcon/>
         </router-link>
         <span class="not-link" v-else><ChevronLeftIcon/></span>
@@ -16,13 +16,13 @@
         <span v-else>&nbsp;</span>
       </li>
       <li class="pagination__item">
-        <router-link v-if="currentPage < totalPages" :to="{ name: baseRoute, params: { page: currentPage + 1, address }}">
+        <router-link v-if="currentPage < totalPages" :to="{ name: baseRoute, params: { address }, query: { [queryKey]: currentPage + 1 }}">
           <ChevronRightIcon/>
         </router-link>
         <span class="not-link" v-else><ChevronRightIcon/></span>
       </li>
       <li class="pagination__item">
-        <router-link v-if="currentPage < totalPages" :to="{ name: baseRoute, params: { page: totalPages, address }}">
+        <router-link v-if="currentPage < totalPages" :to="{ name: baseRoute, params: { address }, query: { [queryKey]: totalPages }}">
           Last
         </router-link>
         <span class="not-link" v-else>Last</span>
@@ -37,7 +37,12 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/solid';
 export default {
   name: 'Pagination',
   components: { ChevronRightIcon, ChevronLeftIcon },
-  props: ['baseRoute', 'address', 'currentPage', 'totalPages']
+  props: ['baseRoute', 'address', 'currentPage', 'totalPages', 'query'],
+  computed: {
+    queryKey: function() {
+      return this.query || 'page';
+    }
+  }
 }
 </script>
 

--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -101,7 +101,7 @@ export default {
     },
     async fetchData() {
       this.blockId = this.$route.params.blockId
-      this.page = parseInt(this.$route.params.page || 1)
+      this.page = parseInt(this.$route.query.page || 1)
 
       if (this.blockId) {
         this.loading = true

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -102,7 +102,7 @@ export default {
       this.loading = true
 
       this.stakeId = this.$route.params.stakeId
-      this.page = parseInt(this.$route.params.page || 1)
+      this.page = parseInt(this.$route.query.page || 1)
 
       if (this.stakeId) {
         const stake = await fetchStake(this.stakeId)

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -97,7 +97,7 @@ export default {
       this.loading = true
 
       this.hash = this.$route.params.hash
-      this.page = parseInt(this.$route.params.page || 1)
+      this.page = parseInt(this.$route.query.page || 1)
 
       if (this.hash) {
         const { raw, transactions } = await fetchTransactions({ hash: this.hash })

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -14,11 +14,11 @@
 
           <h3>Wallet Transactions</h3>
           <TransactionsTable :transactions="transactions" />
-          <Pagination v-if="transactions" baseRoute="Wallet" :address="address" :currentPage="page" :totalPages="Math.ceil(metadata.totalCount/metadata.limit)" />
+          <Pagination v-if="transactions" baseRoute="Wallet" :address="address" :currentPage="txsPage" :totalPages="Math.ceil(metadata.totalCount/metadata.limit)" query="txsPage" />
         </div>
         <div v-else>
           <WalletsTable :wallets="wallets" />
-          <Pagination v-if="wallets" baseRoute="Wallets" :currentPage="page" :totalPages="Math.ceil(metadata.totalCount/metadata.limit)" />
+          <Pagination v-if="wallets" baseRoute="Wallets" :currentPage="page" :totalPages="Math.ceil(metadata.totalCount/metadata.limit)" query="page" />
         </div>
       </div>
       <div v-else class="container h-full">
@@ -65,6 +65,7 @@ export default {
       loading: true,
       metadata: {},
       page: 1,
+      txsPage: 1,
       pollInterval: 10000,
       polling: null,
       rawData: null,
@@ -93,7 +94,8 @@ export default {
     },
     async fetchData() {
       this.address = this.$route.params.address
-      this.page = parseInt(this.$route.params.page || 1)
+      this.page = parseInt(this.$route.query.page || 1)
+      this.txsPage = parseInt(this.$route.query.txsPage || 1)
 
       if (this.address && checksumAddressIsValid(this.address)) {
         if (!this.wallet) {
@@ -101,7 +103,7 @@ export default {
         }
 
         this.loading = true
-        const { transactions, metadata } = await fetchTransactions({ address: this.address, options: { page: this.page } })
+        const { transactions, metadata } = await fetchTransactions({ address: this.address, options: { page: this.txsPage } })
         const wallet = await fetchWallet(this.address)
 
         this.transactions = transactions
@@ -118,7 +120,6 @@ export default {
     },
     async fetchWallets(options) {
       const { results, metadata } = await fetchWallets(options)
-
       this.wallets = results
       this.metadata = metadata
       this.loading = false


### PR DESCRIPTION
For #77 

Wasn't too difficult in the end. 

The idea is if you need multiple tables with pages, add a `query` prop to Pagination with the name of the query (e.g. txsPage or stakesPage). If no `query` prop is added it defaults to "page". 

Then just pass the right page value into the fetchData function. 