### PR TITLE
fix/navigate back from tables

### DIFF
--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -122,7 +122,7 @@ export default {
       this.fetchData()
     }
     const p = parseInt(this.$route.query.page) || 0
-    if (p < 1) this.$router.push({ name: this.baseRoute, query: { page: 1 } })
+    if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
   },
   methods: {
     async fetchBlocks(options) {
@@ -170,7 +170,7 @@ export default {
   watch:{
     metadata() {
       // clamp pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: this.baseRoute, query: { page: this.lastPage } })
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }
 }

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -101,7 +101,7 @@ export default {
       this.fetchData()
     } else {
       const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.push({ name: this.baseRoute, query: { page: 1 } })
+      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   computed: {
@@ -161,7 +161,7 @@ export default {
     },
     metadata() {
       // clamp pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: this.baseRoute, query: { page: this.lastPage } })
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }
 }

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -108,7 +108,7 @@ export default {
       })
     } else {
       const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.push({ name: this.baseRoute, query: { page: 1 } })
+      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   methods: {
@@ -167,7 +167,7 @@ export default {
     },
     metadata() {
       // clamp pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: 'Transactions', query: { page: this.lastPage } })
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }
 }

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -156,11 +156,11 @@ export default {
       // clamp tx and stakes tables to page 1
       const txP = parseInt(this.$route.query.txsPage) || 0
       const stakesP = parseInt(this.$route.query.stakesPage) || 0
-      if (txP < 1) this.$router.push({ name: 'Wallet', query: { ...this.$route.query, txsPage: 1 } })
-      if (stakesP < 1) this.$router.push({ name: 'Wallet', query: { ...this.$route.query, stakesPage: 1 } })
+      if (txP < 1) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
+      if (stakesP < 1) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
     } else {
       const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.push({ name: 'Wallets', query: { page: 1 } })
+      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   methods: {
@@ -209,15 +209,15 @@ export default {
     },
     metadata() {
       // clamp wallets pagination to available page numbers with automatic redirection
-      if (this.currentPage > this.lastPage) this.$router.push({ name: 'Wallets', query: { page: this.lastPage } })
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     },
     stakesMetadata() {
       // clamp stakes pagination to available page numbers with automatic redirection
-      if (this.stakesCurrentPage > this.stakesLastPage) this.$router.push({ name: 'Wallet', query: { stakesPage: this.stakesLastPage } })
+      if (this.stakesCurrentPage > this.stakesLastPage) this.$router.replace({ query: { ...this.$route.query, stakesPage: this.stakesLastPage } })
     },
     txsMetadata() {
       // clamp tx pagination to available page numbers with automatic redirection
-      if (this.txsCurrentPage > this.txsLastPage) this.$router.push({ name: 'Wallet', query: { txsPage: this.txsLastPage } })
+      if (this.txsCurrentPage > this.txsLastPage) this.$router.replace({ query: { ...this.$route.query, txsPage: this.txsLastPage } })
     }
   }
 }


### PR DESCRIPTION
It wasn't possible to navigate back from a table view because of the way page clamping was implemented. I changed `$route.push()` tp `$route.replace` to get around this issue. 