### PR TITLE
Issue/111 network pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.13.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@edge/index-utils": "^0.3.5",
+        "@edge/index-utils": "^0.4.3",
         "@edge/wallet-utils": "0.13.0",
         "@heroicons/vue": "^1.0.1",
         "@metamask/detect-provider": "^1.2.0",
@@ -1630,9 +1630,9 @@
       }
     },
     "node_modules/@edge/index-utils": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.3.5.tgz",
-      "integrity": "sha512-H4mQ1hZp8xC80HVEHvk6AmTMTpn1x8Dac+HxufC0/ZiOMoKFVRm7rkOlphA9mGC8f2gauuGkbknvHRuhzxM36A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.4.3.tgz",
+      "integrity": "sha512-FoJg5nBgwu5k38JiXPj0+AjhLh5/nGT59b6JS4b0Pkms+Qg8A7Ai5nzgKRFKmUgTU0stpDDjmue4ZLvCHxG9Sw==",
       "dependencies": {
         "superagent": "^6.1.0 || ^7.0.0"
       }
@@ -17282,9 +17282,9 @@
       }
     },
     "@edge/index-utils": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.3.5.tgz",
-      "integrity": "sha512-H4mQ1hZp8xC80HVEHvk6AmTMTpn1x8Dac+HxufC0/ZiOMoKFVRm7rkOlphA9mGC8f2gauuGkbknvHRuhzxM36A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@edge/index-utils/-/index-utils-0.4.3.tgz",
+      "integrity": "sha512-FoJg5nBgwu5k38JiXPj0+AjhLh5/nGT59b6JS4b0Pkms+Qg8A7Ai5nzgKRFKmUgTU0stpDDjmue4ZLvCHxG9Sw==",
       "requires": {
         "superagent": "^6.1.0 || ^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "server/index.js",
   "dependencies": {
-    "@edge/index-utils": "^0.3.5",
+    "@edge/index-utils": "^0.4.3",
     "@edge/wallet-utils": "0.13.0",
     "@heroicons/vue": "^1.0.1",
     "@metamask/detect-provider": "^1.2.0",

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto+Mono:wght@300&display=swap" rel="stylesheet">
     <script src="<%= BASE_URL %>assets/js/bodyScrollLock.js"></script>
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -42,6 +42,10 @@
           {
             link: "/wallets",
             text: "Wallets"
+          },
+          {
+            link: "/nodes",
+            text: "Nodes"
           }
         ]
       }

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -109,7 +109,7 @@ export default {
     },
     isOnline(node) {
       if (this.node) return Date.now() - node.lastActive < 60000
-      return Date.now() - node.lastSeen < 60000
+      return Date.now() - node.lastActive < 60000
     },
     async updateNodes() {
       this.loading = true

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="flex flex-col h-full">
+    <h3>{{ node ? "Node Location" : "Network Map"}}</h3>
+    <div id="network_map"></div>
+  </div>
+</template>
+
+<script>
+import * as index from '@edge/index-utils'
+
+const mapRefreshInterval = 60 * 1000
+
+// FOR TESTING
+function getRandomLatLng(min, max) {
+  return Math.random() * (max - min) + min
+}
+
+export default {
+  name: "NetworkMap",
+  data: function () {
+    return {
+      mapInterval: null,
+      nodes: null,
+      options: {
+        backgroundColor: '#181818',
+        datalessRegionColor: '#808080',
+        defaultColor: '#0ecd61',
+        displayMode: 'markers',
+        magnifyingGlass: {enable: true, zoomFactor: 5},
+        legend: 'none',
+        tooltip: {trigger: 'none',},
+        colorAxis: {colors: ['#555', '#0ecd61']},
+      }
+    }
+  },
+  props: [
+    'node'
+  ],
+  computed: {
+    sizeAxis() {
+      if (this.node) return {minSize: 6, maxSize: 8}
+      return {minSize: 5, maxSize: 9}
+    }
+  },
+  mounted() {
+    this.loadMap()
+    if (!this.node) {
+      // initiate polling
+      this.mapInterval = setInterval(() => {
+        this.loadMap()
+      }, mapRefreshInterval)
+    }
+  },
+  umounted() {
+    if (!this.node) {
+      clearInterval(this.mapInterval)
+    }
+  },
+  methods: {
+    async drawMap() {
+      await this.updateNodes()
+      // colours are set by online: 0 = offline / 1 = online
+      // size is set by type: 0 = host / 1 = gateway / 2 = stargate
+      const nodeTable = [['lat', 'lng', 'online', 'type']]
+      if (this.node) {
+        const nodes = [this.node]
+        if (this.node.gateway) nodes.push(this.node.gateway)
+        if (this.node.stargate) nodes.push(this.node.stargate)
+        nodes.forEach(node => {
+          const online = this.isOnline(node) ? 1 : 0
+          const type = node.node.type === 'host' ? 0 : node.node.type === 'gateway' ? 1 : 2
+
+          if (process.env.VUE_APP_INDEX_API_URL.includes('test')) {
+            // randomly generate UK co-ordinates for testnet nodes
+            const ranLat = getRandomLatLng(51.5, 58.5)
+            const ranLng = getRandomLatLng(-9.7, 1.7)
+            nodeTable.push([ranLat, ranLng, online, type])
+          } else {
+            nodeTable.push([node.node.geo.lat, node.node.geo.lng, online, type])
+          }
+        })
+      }
+      else {
+        this.nodes.forEach(node => {
+          const online = this.isOnline(node) ? 1 : 0
+          const type = node.node.type === 'host' ? 0 : node.node.type === 'gateway' ? 1 : 2
+
+          if (process.env.VUE_APP_INDEX_API_URL.includes('test')) {
+            // randomly generate world co-ordinates for testnet nodes
+            // TESTING
+            const ranLat = getRandomLatLng(51.5, 58.5)
+            const ranLng = getRandomLatLng(-9.7, 1.7)
+            // const ranLat = getRandomLatLng(90, -90)
+            // const ranLng = getRandomLatLng(180, -180)
+            nodeTable.push([ranLat, ranLng, online, type])
+          } else {
+            nodeTable.push([node.node.geo.lat, node.node.geo.lng, online, type])
+          }
+        })
+      }
+
+      const data = google.visualization.arrayToDataTable(nodeTable)
+      const map = new google.visualization.GeoChart(document.getElementById('network_map'))
+      const options = this.options
+      options.sizeAxis = this.sizeAxis
+      if (this.node) options.region = this.node.node.geo.countryCode
+      // TESTING
+      options.region = 'GB'
+      map.draw(data, options)
+    },
+    loadMap() {
+      google.charts.load('current', {
+        'packages':['geochart'],
+      })
+      google.charts.setOnLoadCallback(this.drawMap)
+    },
+    isOnline(node) {
+      if (this.node) return Date.now() - node.lastActive < 60000
+      return Date.now() - node.lastSeen < 60000
+    },
+    async updateNodes() {
+      this.loading = true
+      // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
+      const sessions = await index.session.sessions(process.env.VUE_APP_INDEX_API_URL, { limit: 1000 })
+      this.nodes = sessions.results
+      this.loaded = true
+      this.loading = false
+    },
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -10,19 +10,19 @@
       <div class="nodeRow">
         <div class="nodeRow__label">Address</div>
         <div class="nodeRow__value">
-          <router-link :to="addressRoute">{{ node.node.address }}</router-link>
+          <router-link :to="addressRoute">{{ session.node.address }}</router-link>
         </div>
       </div>
-      <div class="nodeRow" v-if="node.gateway">
+      <div class="nodeRow" v-if="session.gateway">
         <div class="nodeRow__label">Gateway</div>
         <div class="nodeRow__value">
-          <router-link :to="gatewayRoute">{{ node.gateway.node.address }}</router-link>
+          <router-link :to="gatewayRoute">{{ session.gateway.node.address }}</router-link>
         </div>
       </div>
-      <div class="nodeRow" v-if="node.stargate">
+      <div class="nodeRow" v-if="session.stargate">
         <div class="nodeRow__label">Stargate</div>
         <div class="nodeRow__value">
-          <router-link  :to="stargateRoute">{{ node.stargate.node.address }}</router-link>
+          <router-link  :to="stargateRoute">{{ session.stargate.node.address }}</router-link>
         </div>
       </div>
       <div class="nodeRow">
@@ -35,7 +35,7 @@
       </div>
       <div class="nodeRow">
         <div class="nodeRow__label">Availability</div>
-        <div class="nodeRow__value">{{ (node.availability * 100).toFixed(2) }}%</div>
+        <div class="nodeRow__value">{{ (session.availability * 100).toFixed(2) }}%</div>
       </div>
       <div class="nodeRow">
         <div class="nodeRow__label">Location</div>
@@ -52,31 +52,31 @@ import moment from 'moment'
 export default {
   name: "NodeOverview",
   props: {
-    node: {
+    session: {
       type: Object
     }
   },
   computed: {
     addressRoute() {
-      return {name: 'Node', params: {address: this.node.node.address}}
+      return {name: 'Node', params: {address: this.session.node.address}}
     },
     formattedType() {
-      return this.node.node.type.charAt(0).toUpperCase() + this.node.node.type.slice(1)
+      return this.session.node.type.charAt(0).toUpperCase() + this.session.node.type.slice(1)
     },
     gatewayRoute() {
-      if (this.node.gateway) return {name: 'Node', params: {address: this.node.gateway.node.address}}
+      if (this.session.gateway) return {name: 'Node', params: {address: this.session.gateway.node.address}}
     },
     isOnline() {
-      return Date.now() - this.node.lastActive < 60000
+      return Date.now() - this.session.lastActive < 60000
     },
     lastActive() {
-      return moment(this.node.lastActive).fromNow()
+      return moment(this.session.lastActive).fromNow()
     },
     location() {
-      return `${this.node.node.geo.city}, ${this.node.node.geo.country}`
+      return `${this.session.node.geo.city}, ${this.session.node.geo.country}`
     },
     stargateRoute() {
-      if (this.node.stargate) return {name: 'Node', params: {address: this.node.stargate.node.address}}
+      if (this.session.stargate) return {name: 'Node', params: {address: this.session.stargate.node.address}}
     },
     status() {
       if (this.isOnline) return 'Online'

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -31,7 +31,7 @@
       </div>
       <div class="nodeRow" v-if="!isOnline">
         <div class="nodeRow__label">Last Seen</div>
-        <div class="nodeRow__value">{{ lastSeen }}</div>
+        <div class="nodeRow__value">{{ lastActive }}</div>
       </div>
       <div class="nodeRow">
         <div class="nodeRow__label">Availability</div>
@@ -69,7 +69,7 @@ export default {
     isOnline() {
       return Date.now() - this.node.lastActive < 60000
     },
-    lastSeen() {
+    lastActive() {
       return moment(this.node.lastActive).fromNow()
     },
     location() {

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="flex flex-col h-full">
+    <h3>Node Overview</h3>
+
+    <div class="flex flex-col flex-1 space-y-2">
+      <div class="nodeRow">
+        <div class="nodeRow__label">Address</div>
+        <div class="nodeRow__value">
+          <router-link :to="addressRoute">{{ node.address }}</router-link>
+        </div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Gateway</div>
+        <div class="nodeRow__value">
+          <router-link v-if="node.gateway" :to="gatewayRoute">{{ node.gateway }}</router-link>
+          <span v-else>N/A</span>
+        </div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Stargate</div>
+        <div class="nodeRow__value">
+          <router-link v-if="node.stargate" :to="stargateRoute">{{ node.stargate }}</router-link>
+          <span v-else>N/A</span>
+        </div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Type</div>
+        <div class="nodeRow__value">{{ node.type.slice(0, 1).toUpperCase() + node.type.slice(1) }}</div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Availability</div>
+        <div class="nodeRow__value">{{ node.availability.toFixed(2) }}%</div>
+      </div>
+      <div class="nodeRow" v-if="node.device">
+        <div class="nodeRow__label">Last Seen</div>
+        <div class="nodeRow__value">{{ lastSeen }}</div>
+      </div>
+    </div>
+
+  </div>
+</template>
+
+<script>
+import { ClockIcon, StatusOnlineIcon } from '@heroicons/vue/outline'
+import moment from 'moment'
+import Tooltip from '@/components/Tooltip'
+
+export default {
+  name: "NodeOverview",
+  components: {
+    ClockIcon,
+    StatusOnlineIcon,
+    Tooltip
+  },
+  props: {
+    node: {
+      type: Object
+    }
+  },
+  computed: {
+    addressRoute() {
+      return {name: 'Node', params: {address: this.node.address}}
+    },
+    gatewayRoute() {
+      return {name: 'Node', params: {address: this.node.gateway}}
+    },
+    stargateRoute() {
+      return {name: 'Node', params: {address: this.node.stargate}}
+    },
+    formattedType() {
+      return this.node.type.charAt(0).toUpperCase() + this.node.type.slice(1)
+    },
+    isOnline() {
+      return Date.now() - this.node.lastSeen < 60000
+    },
+    lastSeen() {
+      if (this.isOnline) return 'Online'
+      return moment(this.node.lastSeen).fromNow()
+    }
+  }
+}
+</script>
+
+<style scoped>
+.nodeRow {
+  @apply px-12 md:px-24 py-12 text-sm bg-white rounded w-full grid grid-cols-12 items-center;
+}
+
+.nodeRow .icon-green {
+  @apply text-green;
+}
+
+.nodeRow .icon-grey {
+  @apply text-gray-400;
+}
+
+.nodeRow__label {
+  @apply col-span-4 md:col-span-3;
+}
+
+.nodeRow__value {
+  @apply font-mono col-span-8 text-gray-300 md:col-span-9;
+}
+
+.nodeRow__value a {
+  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+</style>

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -99,7 +99,7 @@ export default {
 }
 
 .nodeRow__value {
-  @apply font-mono col-span-8 text-gray-300 md:col-span-9;
+  @apply font-mono col-span-8 text-gray-300 md:col-span-9 truncate;
 }
 
 .nodeRow__value a {

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col h-full">
     <h3>Node Summary</h3>
     <div class="relative max-h-full tile md:pr-50">
-      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.node.address }}</span> <span v-if="isOnline">is currently online</span><span v-else>was last seen {{ lastSeen }}</span>. It has been available for <span class="emphasis">{{ (node.availability * 100).toFixed(2) }}%</span> of the last 24 hours. It is located in <span class="emphasis">{{ location }}</span>.
+      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.node.address }}</span> <span v-if="isOnline">is currently online</span><span v-else>was last seen {{ lastActive }}</span>. It has been available for <span class="emphasis">{{ (node.availability * 100).toFixed(2) }}%</span> of the last 24 hours. It is located in <span class="emphasis">{{ location }}</span>.
 
       <span v-if="node.node.type === 'gateway'">
         It is currently connected to Stargate <span class="emphasis">{{ node.stargate.node.address }}</span>.
@@ -32,7 +32,7 @@ export default {
     isOnline() {
       return Date.now() - this.node.lastActive < 60000
     },
-    lastSeen() {
+    lastActive() {
       if (this.isOnline) return 'Online'
       return moment(this.node.lastActive).fromNow()
     },

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -2,23 +2,15 @@
   <div class="flex flex-col h-full">
     <h3>Node Summary</h3>
     <div class="relative max-h-full tile md:pr-50">
-      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.address }}</span>
-      <span v-if="isOnline"> is currently online. </span><span v-else> was last seen {{ lastSeen }}. </span>It has been available for <span class="emphasis">{{ node.availability.toFixed(2) }}%</span> of the last 24 hours.
+      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.node.address }}</span> <span v-if="isOnline">is currently online</span><span v-else>was last seen {{ lastSeen }}</span>. It has been available for <span class="emphasis">{{ (node.availability * 100).toFixed(2) }}%</span> of the last 24 hours. It is located in <span class="emphasis">{{ location }}</span>.
 
-      <br><br>
-
-      <span v-if="node.type === 'stargate'">
-        <span class="emphasis"> {{ node.gatewaysConnected }}</span> gateways and <span class="emphasis">{{ node.hosts }}</span> hosts are connected to it.</span>
-      <span v-else-if="node.type === 'gateway'">
-        <span class="emphasis">{{ node.hostsConnected }}</span> host nodes are connected to it and its stargate node is <span class="emphasis">{{ node.stargate }}.</span>
+      <span v-if="node.node.type === 'gateway'">
+        It is currently connected to Stargate <span class="emphasis">{{ node.stargate.node.address }}</span>.
       </span>
-      <span v-else>
-        Its gateway node is <span class="emphasis">{{ node.gateway }}</span> and its stargate node is <span class="emphasis">{{ node.stargate }}.</span>
+      <span v-if="node.node.type === 'host'">
+        It is currently connected to Gateway <span class="emphasis">{{ node.gateway.node.address }}</span> and Stargate <span class="emphasis">{{ node.stargate.node.address }}</span>.
       </span>
 
-      <br><br>
-
-      This node is located in <span class="emphasis">{{ node.geo.location }}</span> at <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> lattitude by <span class="emphasis">{{ node.geo.lng.toFixed(2) }}&#176;</span> longtitude.
     </div>
   </div>
 </template>
@@ -34,24 +26,18 @@ export default {
     }
   },
   computed: {
-    addressRoute() {
-      return {name: 'Node', params: {address: this.node.address}}
-    },
-    gatewayRoute() {
-      return {name: 'Node', params: {address: this.node.gateway}}
-    },
-    stargateRoute() {
-      return {name: 'Node', params: {address: this.node.stargate}}
-    },
     formattedType() {
-      return this.node.type.charAt(0).toUpperCase() + this.node.type.slice(1)
+      return this.node.node.type.charAt(0).toUpperCase() + this.node.node.type.slice(1)
     },
     isOnline() {
-      return Date.now() - this.node.lastSeen < 60000
+      return Date.now() - this.node.lastActive < 60000
     },
     lastSeen() {
       if (this.isOnline) return 'Online'
-      return moment(this.node.lastSeen).fromNow()
+      return moment(this.node.lastActive).fromNow()
+    },
+    location() {
+      return `${this.node.node.geo.city}, ${this.node.node.geo.country}`
     }
   }
 }

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -18,7 +18,7 @@
 
       <br><br>
 
-      This node is located in <span class="emphasis">{{ node.geo.location }}</span> at <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> lattitude by <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> longtitude.
+      This node is located in <span class="emphasis">{{ node.geo.location }}</span> at <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> lattitude by <span class="emphasis">{{ node.geo.lng.toFixed(2) }}&#176;</span> longtitude.
     </div>
   </div>
 </template>

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -2,13 +2,13 @@
   <div class="flex flex-col h-full">
     <h3>Node Summary</h3>
     <div class="relative max-h-full tile md:pr-50">
-      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.node.address }}</span> <span v-if="isOnline">is currently online</span><span v-else>was last seen {{ lastActive }}</span>. It has been available for <span class="emphasis">{{ (node.availability * 100).toFixed(2) }}%</span> of the last 24 hours. It is located in <span class="emphasis">{{ location }}</span>.
+      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ session.node.address }}</span> is currently <span v-if="isOnline">online</span><span v-else>offline and was last seen {{ lastActive }}</span>. It has been available for <span class="emphasis">{{ (session.availability * 100).toFixed(2) }}%</span> of the last 24 hours. It is located in <span class="emphasis">{{ location }}</span>.
 
-      <span v-if="node.node.type === 'gateway'">
-        It is currently connected to Stargate <span class="emphasis">{{ node.stargate.node.address }}</span>.
+      <span v-if="isOnline && session.node.type === 'gateway'">
+        It is currently connected to Stargate <span class="emphasis">{{ session.stargate.node.address }}</span>.
       </span>
-      <span v-if="node.node.type === 'host'">
-        It is currently connected to Gateway <span class="emphasis">{{ node.gateway.node.address }}</span> and Stargate <span class="emphasis">{{ node.stargate.node.address }}</span>.
+      <span v-if="isOnline && session.node.type === 'host'">
+        It is currently connected to Gateway <span class="emphasis">{{ session.gateway.node.address }}</span> and Stargate <span class="emphasis">{{ session.stargate.node.address }}</span>.
       </span>
 
     </div>
@@ -21,23 +21,22 @@ import moment from 'moment'
 export default {
   name: "NodeSummary",
   props: {
-    node: {
+    session: {
       type: Object
     }
   },
   computed: {
     formattedType() {
-      return this.node.node.type.charAt(0).toUpperCase() + this.node.node.type.slice(1)
+      return this.session.node.type.charAt(0).toUpperCase() + this.session.node.type.slice(1)
     },
     isOnline() {
-      return Date.now() - this.node.lastActive < 60000
+      return Date.now() - this.session.lastActive < 60000
     },
     lastActive() {
-      if (this.isOnline) return 'Online'
-      return moment(this.node.lastActive).fromNow()
+      return moment(this.session.lastActive).fromNow()
     },
     location() {
-      return `${this.node.node.geo.city}, ${this.node.node.geo.country}`
+      return `${this.session.node.geo.city}, ${this.session.node.geo.country}`
     }
   }
 }

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="flex flex-col h-full">
+    <h3>Node Summary</h3>
+    <div class="relative max-h-full tile md:pr-50">
+      <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.address }}</span>
+      <span v-if="isOnline"> is currently online. </span><span v-else> was last seen {{ lastSeen }}. </span>
+
+      <span v-if="node.type === 'stargate'">
+        <span class="emphasis"> {{ node.gatewaysConnected }}</span> gateways and <span class="emphasis">{{ node.hosts }}</span> hosts are connected to it.</span>
+      <span v-else-if="node.type === 'gateway'">
+        <span class="emphasis">{{ node.hostsConnected }}</span> host nodes are connected to it and its stargate node is <span class="emphasis">{{ node.stargate }}.</span>
+      </span>
+      <span v-else>
+        Its gateway node is <span class="emphasis">{{ node.gateway }}</span> and its stargate node is <span class="emphasis">{{ node.stargate }}.</span>
+      </span>
+
+      It has been available for <span class="emphasis">{{ node.availability.toFixed(2) }}%</span> of the last 24 hours.
+
+      <br><br>
+
+      This node is located in <span class="emphasis">{{ node.geo.location }}</span> at <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> lattitude by <span class="emphasis">{{ node.geo.lat.toFixed(2) }}&#176;</span> longtitude.
+    </div>
+  </div>
+</template>
+
+<script>
+import moment from 'moment'
+
+export default {
+  name: "NodeSummary",
+  props: {
+    node: {
+      type: Object
+    }
+  },
+  computed: {
+    addressRoute() {
+      return {name: 'Node', params: {address: this.node.address}}
+    },
+    gatewayRoute() {
+      return {name: 'Node', params: {address: this.node.gateway}}
+    },
+    stargateRoute() {
+      return {name: 'Node', params: {address: this.node.stargate}}
+    },
+    formattedType() {
+      return this.node.type.charAt(0).toUpperCase() + this.node.type.slice(1)
+    },
+    isOnline() {
+      return Date.now() - this.node.lastSeen < 60000
+    },
+    lastSeen() {
+      if (this.isOnline) return 'Online'
+      return moment(this.node.lastSeen).fromNow()
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .tile {
+    @apply flex-1 p-12 md:p-24 text-sm text-gray-300 bg-white rounded;
+  }
+  .tile span.emphasis {
+    @apply text-gray-900 font-medium font-mono;
+  }
+  button {
+    @apply leading-none text-sm2 border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  }
+</style>

--- a/src/components/NodeSummary.vue
+++ b/src/components/NodeSummary.vue
@@ -3,7 +3,9 @@
     <h3>Node Summary</h3>
     <div class="relative max-h-full tile md:pr-50">
       <span class="emphasis">{{ formattedType }}</span> node <span class="emphasis">{{ node.address }}</span>
-      <span v-if="isOnline"> is currently online. </span><span v-else> was last seen {{ lastSeen }}. </span>
+      <span v-if="isOnline"> is currently online. </span><span v-else> was last seen {{ lastSeen }}. </span>It has been available for <span class="emphasis">{{ node.availability.toFixed(2) }}%</span> of the last 24 hours.
+
+      <br><br>
 
       <span v-if="node.type === 'stargate'">
         <span class="emphasis"> {{ node.gatewaysConnected }}</span> gateways and <span class="emphasis">{{ node.hosts }}</span> hosts are connected to it.</span>
@@ -13,8 +15,6 @@
       <span v-else>
         Its gateway node is <span class="emphasis">{{ node.gateway }}</span> and its stargate node is <span class="emphasis">{{ node.stargate }}.</span>
       </span>
-
-      It has been available for <span class="emphasis">{{ node.availability.toFixed(2) }}%</span> of the last 24 hours.
 
       <br><br>
 

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -18,7 +18,7 @@
           sortParam="sortAvailability" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="12%" header="Last Seen" :sortQuery="sortQuery"
-          sortParam="lastSeen" :onSortingUpdate="updateSorting"
+          sortParam="lastActive" :onSortingUpdate="updateSorting"
         />
       </tr>
       <tr v-else>

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -103,7 +103,7 @@ export default {
     async updateNodes() {
       this.loading = true
       // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
-      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-lastSeen,node.address` : '-lastSeen,node.address'
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-lastActive,node.address` : '-lastActive,node.address'
       const sessions = await index.session.sessions(
         process.env.VUE_APP_INDEX_API_URL,
         {

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -1,0 +1,184 @@
+<template>
+  <table>
+    <thead class="hidden lg:table-header-group">
+      <tr v-if="sortable">
+        <TableHeader width="12%" header="ID" :sortQuery="sortQuery"
+          sortParam="id" :onSortingUpdate="updateSorting"
+        />
+        <TableHeader width="12%" header="Hash" :sortQuery="sortQuery"
+          sortParam="hash" :onSortingUpdate="updateSorting"
+        />
+        <th width="23%">Wallet</th>
+        <TableHeader width="20%" header="Device" :sortQuery="sortQuery"
+          sortParam="device" :onSortingUpdate="updateSorting"
+        />
+        <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
+          sortParam="type" :onSortingUpdate="updateSorting"
+        />
+        <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
+          sortParam="released,unlockRequested" :onSortingUpdate="updateSorting"
+        />
+        <TableHeader class="amount-col" width="15%" header="Amount XE" :sortQuery="sortQuery"
+          sortParam="amount" :onSortingUpdate="updateSorting"
+        />
+      </tr>
+      <tr v-else>
+        <th width="20%">Address</th>
+        <th width="20%">Gateway</th>
+        <th width="20%">Stargate</th>
+        <th width="8%">Type</th>
+        <th width="12%">Location</th>
+        <th width="8%">Availability</th>
+        <th width="12%">Last Seen</th>
+      </tr>
+    </thead>
+    <tbody v-if="nodes.length">
+      <NodesTableItem
+        v-for="item in nodes"
+        :key="item.id"
+        :item="item"
+      />
+    </tbody>
+    <tbody v-else-if="!loaded & loading">
+      <td colspan="7" class="block w-full text-center bg-white lg:table-cell py-35">
+        Loading...
+      </td>
+    </tbody>
+    <tbody v-else>
+      <tr>
+        <td colspan="7" class="block w-full text-center bg-white lg:table-cell py-35">
+          No Nodes.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script>
+/*global process*/
+import * as index from '@edge/index-utils'
+import NodesTableItem from '@/components/NodesTableItem'
+import TableHeader from '@/components/TableHeader'
+
+const nodesRefreshInterval = 5 * 1000
+
+export default {
+  name: 'NodesTable',
+  data: function () {
+    return {
+      loaded: false,
+      loading: false,
+      nodes: [],
+      iNodes: null
+    }
+  },
+  components: {
+    NodesTableItem,
+    TableHeader
+  },
+  props: [
+    'limit',
+    'page',
+    'receiveMetadata',
+    'sortable'
+  ],
+  computed: {
+    sortQuery() {
+      return this.$route.query.sort
+    },
+    address() {
+      return this.$route.params.address
+    },
+    stargateAddress() {
+      return this.$route.params.stargate || 'N/a'
+    },
+    gatewayAddress() {
+      return this.$route.params.gateway || 'N/a'
+    }
+  },
+  mounted() {
+    this.updateNodes()
+    // initiate polling
+    this.iNodes = setInterval(() => {
+      this.updateNodes()
+    }, nodesRefreshInterval)
+  },
+  unmounted() {
+    clearInterval(this.iNodes)
+  },
+  methods: {
+    async updateNodes() {
+      this.loading = true
+      // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-created` : '-created'
+      // const nodes = await index.node.nodes(
+      //   process.env.VUE_APP_INDEX_API_URL,
+      //   this.wallet,
+      //   {
+      //     limit: this.limit,
+      //     page: this.page,
+      //     sort: sortQuery
+      //   }
+      // )
+      // this.nodes = nodes.results
+      const nodes = []
+      this.receiveMetadata(nodes.metadata)
+      this.loaded = true
+      this.loading = false
+    },
+    updateSorting(newSortQuery) {
+      const query = { ...this.$route.query, sort: newSortQuery }
+      if (!newSortQuery) delete query.sort
+      this.$router.replace({ query })
+    }
+  },
+  watch: {
+    page() {
+      this.updateNodes()
+    },
+    sortQuery() {
+      this.updateNodes()
+    }
+  }
+}
+</script>
+
+<style scoped>
+table {
+  @apply w-full table-fixed
+}
+
+table, tbody, tr {
+  @apply block;
+}
+
+th {
+  @apply font-normal text-sm2 text-left text-black bg-gray-100 border-b-2 border-gray-200 py-13 px-5;
+}
+
+th:first-of-type {
+  @apply pl-20;
+}
+
+th.amount-col {
+  @apply text-right pr-30
+}
+
+th .icon {
+  @apply w-15 inline-block align-middle text-gray-400;
+}
+
+@screen lg {
+  table {
+    @apply table;
+  }
+
+  tbody {
+    @apply table-row-group;
+  }
+
+  tr {
+    @apply table-row;
+  }
+}
+</style>

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -2,24 +2,23 @@
   <table>
     <thead class="hidden lg:table-header-group">
       <tr v-if="sortable">
-        <TableHeader width="12%" header="ID" :sortQuery="sortQuery"
-          sortParam="id" :onSortingUpdate="updateSorting"
+        <TableHeader width="20%" header="Address" :sortQuery="sortQuery"
+          sortParam="node.address" :onSortingUpdate="updateSorting"
         />
-        <TableHeader width="12%" header="Hash" :sortQuery="sortQuery"
-          sortParam="hash" :onSortingUpdate="updateSorting"
-        />
-        <th width="23%">Wallet</th>
-        <TableHeader width="20%" header="Device" :sortQuery="sortQuery"
-          sortParam="device" :onSortingUpdate="updateSorting"
-        />
+        <!-- currently no sorting on gateway and stargate columns as stargate address isn't contained in a host node's data -->
+        <th width="16%">Gateway</th>
+        <th width="16%">Stargate</th>
         <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
-          sortParam="type" :onSortingUpdate="updateSorting"
+          sortParam="node.type" :onSortingUpdate="updateSorting"
         />
-        <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
-          sortParam="released,unlockRequested" :onSortingUpdate="updateSorting"
+        <TableHeader width="20%" header="Location" :sortQuery="sortQuery"
+          sortParam="node.geo.city" :onSortingUpdate="updateSorting"
         />
-        <TableHeader class="amount-col" width="15%" header="Amount XE" :sortQuery="sortQuery"
-          sortParam="amount" :onSortingUpdate="updateSorting"
+        <TableHeader width="8%" header="Availability" :sortQuery="sortQuery"
+          sortParam="sortAvailability" :onSortingUpdate="updateSorting"
+        />
+        <TableHeader width="12%" header="Last Seen" :sortQuery="sortQuery"
+          sortParam="lastSeen" :onSortingUpdate="updateSorting"
         />
       </tr>
       <tr v-else>
@@ -83,17 +82,11 @@ export default {
     'sortable'
   ],
   computed: {
-    sortQuery() {
-      return this.$route.query.sort
-    },
     address() {
       return this.$route.params.address
     },
-    stargateAddress() {
-      return this.$route.params.stargate
-    },
-    gatewayAddress() {
-      return this.$route.params.gateway
+    sortQuery() {
+      return this.$route.query.sort
     }
   },
   mounted() {
@@ -110,7 +103,7 @@ export default {
     async updateNodes() {
       this.loading = true
       // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
-      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-availability` : '-availability'
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-lastSeen` : '-lastSeen'
       const sessions = await index.session.sessions(
         process.env.VUE_APP_INDEX_API_URL,
         {
@@ -120,6 +113,7 @@ export default {
         }
       )
       
+      // add stargate address to host sessions
       const nodes = await Promise.all(sessions.results.map(async (session) => {
         if (session.node.type === 'host') {
           const gateway = await index.session.session(process.env.VUE_APP_INDEX_API_URL, session.node.gateway)

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -6,15 +6,15 @@
           sortParam="node.address" :onSortingUpdate="updateSorting"
         />
         <!-- currently no sorting on gateway and stargate columns as stargate address isn't contained in a host node's data -->
-        <th width="16%">Gateway</th>
-        <th width="16%">Stargate</th>
+        <th width="15%">Gateway</th>
+        <th width="15%">Stargate</th>
         <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
           sortParam="node.type" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="20%" header="Location" :sortQuery="sortQuery"
           sortParam="node.geo.city" :onSortingUpdate="updateSorting"
         />
-        <TableHeader width="8%" header="Availability" :sortQuery="sortQuery"
+        <TableHeader width="10" header="Availability" :sortQuery="sortQuery"
           sortParam="sortAvailability" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="12%" header="Last Seen" :sortQuery="sortQuery"

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -59,7 +59,7 @@ import * as index from '@edge/index-utils'
 import NodesTableItem from '@/components/NodesTableItem'
 import TableHeader from '@/components/TableHeader'
 
-const nodesRefreshInterval = 5 * 1000
+const nodesRefreshInterval = 60 * 1000
 
 export default {
   name: 'NodesTable',
@@ -103,7 +103,7 @@ export default {
     async updateNodes() {
       this.loading = true
       // the sort query sent to index needs to include "-created", but this is hidden from user in browser url
-      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-lastSeen` : '-lastSeen'
+      const sortQuery = this.$route.query.sort ? `${this.$route.query.sort},-lastSeen,node.address` : '-lastSeen,node.address'
       const sessions = await index.session.sessions(
         process.env.VUE_APP_INDEX_API_URL,
         {

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -1,17 +1,17 @@
 <template>
   <tr>
-    <td data-title="Address:" :title="item.address">
+    <td data-title="Address:" :title="item.node.address">
       <router-link :to="addressRoute">
         <span class="monospace md:inline-block">
-          {{ item.address }}
+          {{ item.node.address }}
         </span>
       </router-link>
     </td>
 
-    <td data-title="Gateway:" :title="item.gateway">
-      <router-link v-if="item.gateway" :to="gatewayRoute">
+    <td data-title="Gateway:" :title="item.node.gateway">
+      <router-link v-if="item.node.gateway" :to="gatewayRoute">
         <span class="monospace md:inline-block">
-          {{ item.gateway }}
+          {{ item.node.gateway }}
         </span>
       </router-link>
       <span v-else class="monospace md:inline-block text-gray">
@@ -19,10 +19,10 @@
       </span>
     </td>
 
-    <td data-title="Stargate:" :title="item.stargate">
-      <router-link v-if="item.stargate" :to="stargateRoute">
+    <td data-title="Stargate:" :title="item.node.stargate">
+      <router-link v-if="item.node.stargate" :to="stargateRoute">
         <span class="monospace md:inline-block">
-          {{ item.stargate }}
+          {{ item.node.stargate }}
         </span>
       </router-link>
       <span v-else class="monospace md:inline-block text-gray">
@@ -34,15 +34,15 @@
       <span class="monospace md:font-sans">{{ formattedType }}</span>
     </td>
 
-    <td data-title="Location:" :title="item.location">
-      <span class="monospace md:font-sans">
-        {{ item.geo.location }}
-      </span>
+    <td data-title="Location:" :title="item.node.geo.city">
+      <div class="overflow"><span class="monospace md:font-sans">
+        {{ `${item.node.geo.city}, ${item.node.geo.country}` }}
+      </span></div>
     </td>
 
     <td data-title="Availability:" :title="item.availability">
       <span class="monospace md:inline-block">
-        {{ item.availability.toFixed(2) }}%
+        {{ (item.availability * 100).toFixed(2) }}%
       </span>
     </td>
 
@@ -73,16 +73,16 @@ export default {
       else return 'Unlock'
     },
     addressRoute() {
-      return {name: 'Node', params: {address: this.item.address}}
+      return {name: 'Node', params: {address: this.item.node.address}}
     },
     gatewayRoute() {
-      return {name: 'Node', params: {address: this.item.gateway}}
+      return {name: 'Node', params: {address: this.item.node.gateway}}
     },
     stargateRoute() {
-      return {name: 'Node', params: {address: this.item.stargate}}
+      return {name: 'Node', params: {address: this.item.node.stargate}}
     },
     formattedType() {
-      return this.item.type.charAt(0).toUpperCase() + this.item.type.slice(1)
+      return this.item.node.type.charAt(0).toUpperCase() + this.item.node.type.slice(1)
     },
     isOnline() {
       return Date.now() - this.item.lastSeen < 60000
@@ -105,6 +105,10 @@ td span {
 }
 
 td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
+}
+
+td .overflow {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -15,7 +15,7 @@
         </span>
       </router-link>
       <span v-else class="monospace md:inline-block text-gray">
-        N/a
+        N/A
       </span>
     </td>
 
@@ -26,7 +26,7 @@
         </span>
       </router-link>
       <span v-else class="monospace md:inline-block text-gray">
-        N/a
+        N/A
       </span>
     </td>
 

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -36,7 +36,7 @@
 
     <td data-title="Location:" :title="item.node.geo.city">
       <div class="overflow"><span class="monospace md:font-sans">
-        {{ `${item.node.geo.city}, ${item.node.geo.country}` }}
+        {{ location }}
       </span></div>
     </td>
 
@@ -83,6 +83,9 @@ export default {
     },
     formattedType() {
       return this.item.node.type.charAt(0).toUpperCase() + this.item.node.type.slice(1)
+    },
+    location() {
+      return `${this.item.node.geo.city}, ${this.item.node.geo.country}`
     },
     isOnline() {
       return Date.now() - this.item.lastSeen < 60000

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -49,7 +49,7 @@
     <td data-title="Last Seen:">
       <span v-if="isOnline" class="mr-1 lg:-mt-2 icon icon-green"><StatusOnlineIcon /></span>
       <span v-else class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
-      <span class="monospace md:font-sans" :class="!isOnline && 'text-gray'">{{ lastSeen }}</span>
+      <span class="monospace md:font-sans" :class="!isOnline && 'text-gray'">{{ lastActive }}</span>
     </td>
   </tr>
 </template>
@@ -90,7 +90,7 @@ export default {
     isOnline() {
       return Date.now() - this.item.lastActive < 60000
     },
-    lastSeen() {
+    lastActive() {
       if (this.isOnline) return 'Online'
       return moment(this.item.lastActive).fromNow()
     }

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -9,19 +9,25 @@
     </td>
 
     <td data-title="Gateway:" :title="item.gateway">
-      <router-link :to="gatewayRoute">
+      <router-link v-if="item.gateway" :to="gatewayRoute">
         <span class="monospace md:inline-block">
           {{ item.gateway }}
         </span>
       </router-link>
+      <span v-else class="monospace md:inline-block text-gray">
+        N/a
+      </span>
     </td>
 
     <td data-title="Stargate:" :title="item.stargate">
-      <router-link :to="stargateRoute">
+      <router-link v-if="item.stargate" :to="stargateRoute">
         <span class="monospace md:inline-block">
           {{ item.stargate }}
         </span>
       </router-link>
+      <span v-else class="monospace md:inline-block text-gray">
+        N/a
+      </span>
     </td>
 
     <td data-title="Type:">
@@ -29,31 +35,34 @@
     </td>
 
     <td data-title="Location:" :title="item.location">
-      <span class="monospace md:inline-block">
-        {{ item.location }}
+      <span class="monospace md:font-sans">
+        {{ item.geo.location }}
       </span>
     </td>
 
     <td data-title="Availability:" :title="item.availability">
       <span class="monospace md:inline-block">
-        {{ item.availability }}
+        {{ item.availability.toFixed(2) }}%
       </span>
     </td>
 
     <td data-title="Last Seen:">
-      <span class="monospace">{{ lastSeen }}</span>
+      <span v-if="!isOnline" class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
+      <span class="monospace md:font-sans" :class="!isOnline && 'text-gray'">{{ lastSeen }}</span>
     </td>
   </tr>
 </template>
 
 <script>
 /*global process*/
-import {  } from '@heroicons/vue/outline'
+import { ClockIcon } from '@heroicons/vue/outline'
+import moment from 'moment'
 
 export default {
   name: 'NodesTableItem',
   props: ['item'],
   components: {
+    ClockIcon
   },
   computed: {
     action() {
@@ -72,6 +81,13 @@ export default {
     },
     formattedType() {
       return this.item.type.charAt(0).toUpperCase() + this.item.type.slice(1)
+    },
+    isOnline() {
+      return Date.now() - this.item.lastSeen < 60000
+    },
+    lastSeen() {
+      if (this.isOnline) return 'Online'
+      return moment(this.item.lastSeen).fromNow()
     }
   }
 }

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -88,11 +88,11 @@ export default {
       return `${this.item.node.geo.city}, ${this.item.node.geo.country}`
     },
     isOnline() {
-      return Date.now() - this.item.lastSeen < 60000
+      return Date.now() - this.item.lastActive < 60000
     },
     lastSeen() {
       if (this.isOnline) return 'Online'
-      return moment(this.item.lastSeen).fromNow()
+      return moment(this.item.lastActive).fromNow()
     }
   }
 }

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -47,7 +47,8 @@
     </td>
 
     <td data-title="Last Seen:">
-      <span v-if="!isOnline" class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
+      <span v-if="isOnline" class="mr-1 lg:-mt-2 icon icon-green"><StatusOnlineIcon /></span>
+      <span v-else class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
       <span class="monospace md:font-sans" :class="!isOnline && 'text-gray'">{{ lastSeen }}</span>
     </td>
   </tr>
@@ -55,14 +56,15 @@
 
 <script>
 /*global process*/
-import { ClockIcon } from '@heroicons/vue/outline'
+import { ClockIcon, StatusOnlineIcon } from '@heroicons/vue/outline'
 import moment from 'moment'
 
 export default {
   name: 'NodesTableItem',
   props: ['item'],
   components: {
-    ClockIcon
+    ClockIcon,
+    StatusOnlineIcon
   },
   computed: {
     action() {

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -67,11 +67,6 @@ export default {
     StatusOnlineIcon
   },
   computed: {
-    action() {
-      if (this.item.released) return null
-      else if (this.item.unlockRequested) return 'Release'
-      else return 'Unlock'
-    },
     addressRoute() {
       return {name: 'Node', params: {address: this.item.node.address}}
     },

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -1,0 +1,144 @@
+<template>
+  <tr>
+    <td data-title="Address:" :title="item.address">
+      <router-link :to="addressRoute">
+        <span class="monospace md:inline-block">
+          {{ item.address }}
+        </span>
+      </router-link>
+    </td>
+
+    <td data-title="Gateway:" :title="item.gateway">
+      <router-link :to="gatewayRoute">
+        <span class="monospace md:inline-block">
+          {{ item.gateway }}
+        </span>
+      </router-link>
+    </td>
+
+    <td data-title="Stargate:" :title="item.stargate">
+      <router-link :to="stargateRoute">
+        <span class="monospace md:inline-block">
+          {{ item.stargate }}
+        </span>
+      </router-link>
+    </td>
+
+    <td data-title="Type:">
+      <span class="monospace md:font-sans">{{ formattedType }}</span>
+    </td>
+
+    <td data-title="Location:" :title="item.location">
+      <span class="monospace md:inline-block">
+        {{ item.location }}
+      </span>
+    </td>
+
+    <td data-title="Availability:" :title="item.availability">
+      <span class="monospace md:inline-block">
+        {{ item.availability }}
+      </span>
+    </td>
+
+    <td data-title="Last Seen:">
+      <span class="monospace">{{ lastSeen }}</span>
+    </td>
+  </tr>
+</template>
+
+<script>
+/*global process*/
+import {  } from '@heroicons/vue/outline'
+
+export default {
+  name: 'NodesTableItem',
+  props: ['item'],
+  components: {
+  },
+  computed: {
+    action() {
+      if (this.item.released) return null
+      else if (this.item.unlockRequested) return 'Release'
+      else return 'Unlock'
+    },
+    addressRoute() {
+      return {name: 'Node', params: {address: this.item.address}}
+    },
+    gatewayRoute() {
+      return {name: 'Node', params: {address: this.item.gateway}}
+    },
+    stargateRoute() {
+      return {name: 'Node', params: {address: this.item.stargate}}
+    },
+    formattedType() {
+      return this.item.type.charAt(0).toUpperCase() + this.item.type.slice(1)
+    }
+  }
+}
+</script>
+
+<style scoped>
+td {
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-none;
+}
+
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
+}
+
+td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
+}
+
+td::before {
+  content: attr(data-title);
+  @apply font-normal mr-8 min-w-100 text-xs text-gray-600 pt-2;
+}
+
+td:first-child {
+  @apply rounded-l-4 pt-8;
+}
+
+td:last-child {
+  @apply rounded-r-4 pb-8 border-b-4 border-gray-200;
+}
+
+td .icon {
+  @apply w-15 inline-block align-middle;
+}
+
+td .icon-green {
+  @apply text-green;
+}
+
+td .icon-grey {
+  @apply text-gray-400;
+}
+
+td a {
+  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+
+@screen lg {
+  td {
+    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+  }
+
+  td:first-child {
+    @apply pl-20 pt-13;
+  }
+
+  td.amount-col {
+    @apply text-right pr-30;
+  }
+
+  td:last-child {
+    @apply pb-13 border-b-2;
+  }
+
+  td:before {
+    @apply hidden;
+  }
+}
+</style>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -29,12 +29,12 @@ const routes = [
   },
   {
     path: '/nodes/',
-    name: 'Node',
+    name: 'Nodes',
     component: Nodes
   },
   {
     path: '/node/:address',
-    name: 'Nodes',
+    name: 'Node',
     component: Nodes
   },
   {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,8 +4,9 @@
 
 import { createRouter, createWebHistory } from 'vue-router'
 import Blocks from '@/views/Blocks'
-import Overview from '@/views/Overview'
+import Nodes from '@/views/Nodes'
 import NotFound from '@/views/404'
+import Overview from '@/views/Overview'
 import Stakes from '@/views/Stakes'
 import Transactions from '@/views/Transactions'
 import Wallets from '@/views/Wallets'
@@ -25,6 +26,16 @@ const routes = [
     path: '/blocks/:page(\\d+)?',
     name: 'Blocks',
     component: Blocks
+  },
+  {
+    path: '/nodes/',
+    name: 'Node',
+    component: Nodes
+  },
+  {
+    path: '/node/:address',
+    name: 'Nodes',
+    component: Nodes
   },
   {
     path: '/stake/:stakeId',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -28,7 +28,7 @@ const routes = [
     component: Blocks
   },
   {
-    path: '/nodes/',
+    path: '/nodes',
     name: 'Nodes',
     component: Nodes
   },

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="flex flex-col h-full">
+    <Header />
+    <HeroPanel v-if="address" :title="'Node'" :address="address" />
+    <HeroPanel v-else :title="'Nodes'" />
+
+    <div class="flex-1 bg-gray-200 py-35">
+      <div v-if="node && address" class="container">
+        <div v-if="node && lastTx">
+          <div class="row mb-25">
+            <!-- <NodeOverview :node="node" /> -->
+            <!-- <NodeSummary :node="node" /> -->
+          </div>
+          <div v-if="rawData" class="mb-25">
+            <RawData :rawData="rawData" />
+          </div>
+        </div>
+      </div>
+      <div v-else-if="!$route.params.address" class="container">
+        <NodesTable
+          :limit="limit"
+          :receiveMetadata="onNodesUpdate"
+          :page="currentPage"
+          :sortable="false"
+        />
+        <Pagination
+          v-if="metadata.totalCount > limit"
+          baseRoute="Network"
+          :currentPage="currentPage"
+          :limit="limit"
+          :totalCount="metadata.totalCount"
+        />
+      </div>
+      <div v-else class="container h-full">
+        <div v-if="!loading" class="flex flex-col items-center justify-center h-full">
+          <h1 class="m-0 mt-20 text-2xl font-bold">This node doesn't exist</h1>
+          <p class="mt-5 mb-0 text-center monospace">
+            Try searching for a different node, or <router-link to="/network" class="underline hover:text-green">view all nodes</router-link>.
+          </p>
+          <router-link to="/network">
+            <a class="mt-20 button button--solid">View all nodes</a>
+          </router-link>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Header from "@/components/Header"
+import HeroPanel from "@/components/HeroPanel"
+import Pagination from "@/components/Pagination";
+import RawData from "@/components/RawData"
+// import NodeOverview from "@/components/NodeOverview"
+// import NodeSummary from "@/components/NodeSummary"
+import NodesTable from "@/components/NodesTable"
+
+import { Node } from '../utils/api'
+
+export default {
+  name: 'Nodes',
+  title() {
+    if (window.location.href.indexOf('/node/') > 0) {
+      const parts = window.location.href.split('/')
+      return 'Node ' + this.sliceString(parts[parts.length - 1], 7)
+    }
+
+    return 'Nodes'
+  },
+  data: function () {
+    return {
+      limit: 20,
+      loading: false,
+      metadata: { totalCount: 0 },
+      node: null,
+      rawData: null,
+    }
+  },
+  components: {
+    Header,
+    HeroPanel,
+    Pagination,
+    RawData,
+    // NodeOverview,
+    // NodeSummary,
+    NodesTable,
+  },
+  mounted() {
+    if (this.$route.params.address) { 
+      this.fetchData()
+    } else {
+      const p = parseInt(this.$route.query.page) || 0
+      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+    }
+  },
+  computed: {
+    baseRoute() {
+      return this.$route.params.address ? 'Node' : 'Nodes'
+    },
+    currentPage() {
+      return Math.max(1, parseInt(this.$route.query.page) || 1)
+    },
+    lastPage() {
+      return Math.max(1, Math.ceil(this.metadata.totalCount / this.limit))
+    },
+    address() {
+      return this.$route.params.address || null
+    }
+  },
+  methods: {
+    async fetchData() {
+      this.loading = true
+      const node = await Node(this.address)
+      this.node = node
+      this.rawData = node
+      this.loading = false
+    },
+    sliceString(string, symbols) {
+      return string.length > symbols ? `${string.slice(0, symbols)}…` : string;
+    },
+    onNodesUpdate(metadata) {
+      this.metadata = metadata
+    },
+  },
+  watch: {
+    $route (to, from) {
+      this.fetchData()
+    },
+    metadata() {
+      // clamp pagination to available page numbers with automatic redirection
+      if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
+    }
+  }
+}
+</script>
+<style scoped>
+  .row {
+    @apply grid items-start grid-cols-1 gap-24;
+    @apply lg:grid-cols-2;
+  }
+</style>

--- a/src/views/Overview.vue
+++ b/src/views/Overview.vue
@@ -5,11 +5,11 @@
     <div class="container">
       <div class="row mb-25" v-if="isTestnet">
         <Statistics :blockMetadata="blockMetadata" :stats="stats" :transactionMetadata="transactionMetadata" />
-        <Faucet />
+        <NetworkMap />
       </div>
       <div class="row mb-25" v-else>
-        <NewsPromo />
         <Statistics :blockMetadata="blockMetadata" :stats="stats" :transactionMetadata="transactionMetadata" />
+        <NetworkMap />
       </div>
 
       <div class="row mt-15">
@@ -22,8 +22,7 @@
 
 <script>
 import Header from "@/components/Header"
-import Faucet from "@/components/Faucet"
-import NewsPromo from "@/components/NewsPromo"
+import NetworkMap from "@/components/NetworkMap"
 import RecentBlocks from "@/components/RecentBlocks"
 import RecentTransactions from "@/components/RecentTransactions"
 import Statistics from "@/components/Statistics"
@@ -49,8 +48,7 @@ export default {
   },
   components: {
     Header,
-    Faucet,
-    NewsPromo,
+    NetworkMap,
     RecentBlocks,
     RecentTransactions,
     Statistics,

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -122,7 +122,6 @@ export default {
     async fetchData() {
       this.loading = true
       const stake = await fetchStake(this.stakeId)
-      console.log(stake)
       this.stake = stake
       await this.fetchStakeTxs(this.stakeId)
       this.rawData = stake


### PR DESCRIPTION
Added new Nodes tab with:
- sortable nodes table to list all nodes
- individual node page with overview table and summary

Also added a Network Map
- currently used only on the Overview page in place of the faucet (testnet) / wiki (mainnet)
- shows if node is online/offline
- has capability to be easily added to indv. node page and will display map focused on country of the node. It currently will show the node plus the respective gateway/stargate nodes, but I think I will remove that feature 

Note: the map is in its first draft, and whilst it's quite simple to implement I feel that it's currently quite limited in what it can do. I will continue to research alternatives to see if I can come up with a better map.