### PR TITLE
Fix/misc fixes 16 03

### DIFF
--- a/src/components/BlocksTable.vue
+++ b/src/components/BlocksTable.vue
@@ -7,13 +7,13 @@
             sortParam="height" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="18%" header="Block Hash" :sortQuery="sortQuery"
-            sortParam="hash" :onSortingUpdate="updateSorting"
+            sortParam="hash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="18%" header="Data Hash" :sortQuery="sortQuery"
-            sortParam="dataHash" :onSortingUpdate="updateSorting"
+            sortParam="dataHash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="18%" header="Ledger Hash" :sortQuery="sortQuery"
-            sortParam="ledgerHash" :onSortingUpdate="updateSorting"
+            sortParam="ledgerHash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <th width="5%">Txs</th>
           <th class="amount-col" width="16%">Total XE</th>

--- a/src/components/BlocksTableItem.vue
+++ b/src/components/BlocksTableItem.vue
@@ -2,13 +2,13 @@
   <tr>
     <td data-title="Height:">
       <router-link :to="blockHeightRoute">
-        <span class="monospace">
+        <span class="monospace md:inline-block max-w-max">
           {{ item.height }}
         </span>
       </router-link>
     </td>
 
-    <td data-title="Block Hash:">
+    <td data-title="Block Hash:" :title="item.hash">
       <router-link :to="blockHashRoute">
         <span class="monospace md:inline-block">
           {{ item.hash }}
@@ -16,32 +16,32 @@
       </router-link>
     </td>
 
-    <td data-title="Data Hash:">
+    <td data-title="Data Hash:" :title="item.dataHash">
       <span class="monospace md:inline-block">
         {{ item.dataHash }}
       </span>
     </td>
 
-    <td data-title="Ledger Hash:">
+    <td data-title="Ledger Hash:" :title="item.ledgerHash">
       <span class="monospace md:inline-block">
         {{ item.ledgerHash }}
       </span>
     </td>
 
-    <td data-title="Transactions:" class="monospace">
-      <!-- {{ item.transactions.length }} -->
-      <!-- delete above and uncomment below when index updated -->
-      {{ item.txCount }}
+    <td data-title="Transactions:">
+      <span class="monospace md:inline-block">{{ item.txCount }}</span>
     </td>
 
-    <td data-title="XE:" class="monospace amount-col">
-      {{ formattedTotal }}
+    <td data-title="XE:" class="monospace amount-col" :title="formattedTotal">
+      <span class="md:inline-block">{{ formattedTotal }}</span>
     </td>
 
-    <td data-title="Mined:">
-      <span class="mr-1 lg:-mt-2 icon"><ClockIcon /></span>
-      <span class="md:text-gray-400 monospace md:font-sans">
-        {{ timeSince }}
+    <td data-title="Mined:" :title="timeSince">
+      <span class="md:inline-block">
+        <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
+        <span class="lg:text-gray-400 monospace lg:font-sans">
+          {{ timeSince }}
+        </span>
       </span>
     </td>
   </tr>
@@ -88,7 +88,7 @@ export default {
 
 <style scoped>
 td {
-  @apply bg-white text-sm2 font-normal flex content-center px-5 break-all max-w-full pb-4 leading-none;
+  @apply bg-white text-sm2 font-normal flex content-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td span {
@@ -96,10 +96,6 @@ td span {
 }
 
 td a {
-  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
-}
-
-td .overflow {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
@@ -125,20 +121,12 @@ td .icon-grey {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
-}
-
-tr.pending {
-  @apply italic text-gray-400;
-}
-
-tr.pending a {
-  @apply italic text-gray-400;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -150,7 +138,7 @@ tr.pending a {
   }
 
   td:last-child {
-    @apply pb-13 border-b-2;
+    @apply pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -111,4 +111,8 @@ export default {
 </script>
 
 <style scoped>
+div {
+  border-radius: 5px;
+  overflow: hidden;
+}
 </style>

--- a/src/components/NetworkMap.vue
+++ b/src/components/NetworkMap.vue
@@ -33,6 +33,12 @@ export default {
   props: [
     'session'
   ],
+  computed: {
+    height() {
+      const screenWidth = window.screen.width
+      return screenWidth > 1023 ? 382 : undefined
+    }
+  },
   mounted() {
     this.loadMap()
     if (!this.session) {
@@ -73,7 +79,7 @@ export default {
       if (this.map === null) this.map = new google.visualization.GeoChart(document.getElementById('network_map'))
 
       // focus on country if viewing single node
-      const options = {...this.options}
+      const options = {...this.options, height: this.height}
       if (this.session) options.region = this.session.node.geo.countryCode
 
       this.map.draw(data, options)

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -8,10 +8,24 @@
         <div class="nodeRow__value">{{ formattedType }}</div>
       </div>
       <div class="nodeRow">
+        <div class="nodeRow__label">Availability</div>
+        <div class="nodeRow__value">{{ (session.availability * 100).toFixed(2) }}%</div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Status</div>
+        <div class="nodeRow__value">{{ status }}</div>
+      </div>
+      <div class="nodeRow" v-if="!isOnline">
+        <div class="nodeRow__label">Last Seen</div>
+        <div class="nodeRow__value">{{ lastActive }}</div>
+      </div>
+      <div class="nodeRow">
+        <div class="nodeRow__label">Location</div>
+        <div class="nodeRow__value">{{ location }}</div>
+      </div>
+      <div class="nodeRow">
         <div class="nodeRow__label">Address</div>
-        <div class="nodeRow__value">
-          <router-link :to="addressRoute">{{ session.node.address }}</router-link>
-        </div>
+        <div class="nodeRow__value">{{ session.node.address }}</div>
       </div>
       <div class="nodeRow" v-if="session.gateway">
         <div class="nodeRow__label">Gateway</div>
@@ -26,20 +40,10 @@
         </div>
       </div>
       <div class="nodeRow">
-        <div class="nodeRow__label">Status</div>
-        <div class="nodeRow__value">{{ status }}</div>
-      </div>
-      <div class="nodeRow" v-if="!isOnline">
-        <div class="nodeRow__label">Last Seen</div>
-        <div class="nodeRow__value">{{ lastActive }}</div>
-      </div>
-      <div class="nodeRow">
-        <div class="nodeRow__label">Availability</div>
-        <div class="nodeRow__value">{{ (session.availability * 100).toFixed(2) }}%</div>
-      </div>
-      <div class="nodeRow">
-        <div class="nodeRow__label">Location</div>
-        <div class="nodeRow__value">{{ location }}</div>
+        <div class="nodeRow__label">Wallet</div>
+        <div class="nodeRow__value">
+          <router-link  :to="walletRoute">{{ session.node.wallet }}</router-link>
+        </div>
       </div>
     </div>
 
@@ -57,9 +61,6 @@ export default {
     }
   },
   computed: {
-    addressRoute() {
-      return {name: 'Node', params: {address: this.session.node.address}}
-    },
     formattedType() {
       return this.session.node.type.charAt(0).toUpperCase() + this.session.node.type.slice(1)
     },
@@ -83,6 +84,9 @@ export default {
     status() {
       if (this.isOnline) return 'Online'
       return 'Offline'
+    },
+    walletRoute() {
+      return {name: 'Wallet', params: {address: this.session.node.wallet}}
     }
   }
 }

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -65,7 +65,7 @@ export default {
       return this.session.node.type.charAt(0).toUpperCase() + this.session.node.type.slice(1)
     },
     gatewayRoute() {
-      if (this.session.gateway) return {name: 'Node', params: {address: this.session.gateway.node.address}}
+      if (this.session.gateway) return {name: 'Node', params: {nodeAddress: this.session.gateway.node.address}}
     },
     isOnline() {
       return Date.now() - this.session.lastActive < 60000
@@ -79,7 +79,7 @@ export default {
       else return 'Unknown'
     },
     stargateRoute() {
-      if (this.session.stargate) return {name: 'Node', params: {address: this.session.stargate.node.address}}
+      if (this.session.stargate) return {name: 'Node', params: {nodeAddress: this.session.stargate.node.address}}
     },
     status() {
       if (this.isOnline) return 'Online'

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -12,7 +12,7 @@
           sortParam="node.type" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="20%" header="Location" :sortQuery="sortQuery"
-          sortParam="node.geo.city" :onSortingUpdate="updateSorting" :sortAscFirst="true"
+          sortParam="node.geo.country,node.geo.city" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="98" header="Availability" :sortQuery="sortQuery"
           sortParam="sortAvailability" :onSortingUpdate="updateSorting"

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -3,16 +3,16 @@
     <thead class="hidden lg:table-header-group">
       <tr v-if="sortable">
         <TableHeader width="16%" header="Address" :sortQuery="sortQuery"
-          sortParam="node.address" :onSortingUpdate="updateSorting"
+          sortParam="node.address" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <!-- currently no sorting on gateway and stargate columns as stargate address isn't contained in a host node's data -->
         <th width="15%">Gateway</th>
         <th width="15%">Stargate</th>
         <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
-          sortParam="node.type" :onSortingUpdate="updateSorting"
+          sortParam="node.type" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="20%" header="Location" :sortQuery="sortQuery"
-          sortParam="node.geo.city" :onSortingUpdate="updateSorting"
+          sortParam="node.geo.city" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="98" header="Availability" :sortQuery="sortQuery"
           sortParam="sortAvailability" :onSortingUpdate="updateSorting"

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -31,35 +31,37 @@
     </td>
 
     <td data-title="Type:">
-      <span class="monospace md:font-sans">{{ formattedType }}</span>
+      <span class="monospace md:font-sans md:inline-block">{{ formattedType }}</span>
     </td>
 
-    <td data-title="Location:" :title="item.node.geo.city">
-      <div class="overflow"><span class="monospace md:font-sans" :class="location === 'Unknown' && 'text-gray'">
+    <td data-title="Location:" :title="location">
+      <span class="md:inline-block"><span class="monospace md:font-sans" :class="location === 'Unknown' && 'text-gray'">
         {{ location }}
-      </span></div>
+      </span></span>
     </td>
 
-    <td data-title="Availability:" :title="item.availability">
+    <td data-title="Availability:">
       <span class="monospace md:inline-block">
         {{ (item.availability * 100).toFixed(2) }}%
       </span>
     </td>
 
     <td data-title="Status:">
-      <div v-if="isOnline">
-        <span class="mr-1 lg:-mt-2 icon icon-green"><StatusOnlineIcon /></span>
+      <span v-if="isOnline" class="md:inline-block">
+        <span class="mr-1 -mt-2 icon icon-green"><StatusOnlineIcon /></span>
         <span class="monospace md:font-sans">Online</span>
-      </div>
-      <div v-else>
+      </span>
+      <span v-else class="md:inline-block">
         <span class="mr-1 lg:-mt-2 icon icon-grey"><StatusOfflineIcon /></span>
         <span class="monospace md:font-sans text-gray">Offline</span>
-      </div>
+      </span>
     </td>
 
     <td data-title="Last Seen:">
-      <span class="mr-1 lg:-mt-2 icon icon-grey"><ClockIcon /></span>
-      <span class="monospace md:font-sans text-gray">{{ lastActive }}</span>
+      <span class="md:inline-block">
+        <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
+        <span class="monospace md:font-sans text-gray">{{ lastActive }}</span>
+      </span>
     </td>
   </tr>
 </template>
@@ -120,10 +122,6 @@ td a {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
-td .overflow {
-  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
-}
-
 td::before {
   content: attr(data-title);
   @apply font-normal mr-8 min-w-100 text-xs text-gray-600 pt-2;
@@ -150,24 +148,20 @@ td .icon-grey {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 @screen lg {
   td {
-    @apply border-gray-200 py-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
     @apply pl-20 pt-13;
   }
 
-  td.amount-col {
-    @apply text-right pr-30;
-  }
-
   td:last-child {
-    @apply pb-15 border-b-2;
+    @apply pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -81,13 +81,13 @@ export default {
   },
   computed: {
     addressRoute() {
-      return {name: 'Node', params: {address: this.item.node.address}}
+      return {name: 'Node', params: {nodeAddress: this.item.node.address}}
     },
     gatewayRoute() {
-      return {name: 'Node', params: {address: this.item.node.gateway}}
+      return {name: 'Node', params: {nodeAddress: this.item.node.gateway}}
     },
     stargateRoute() {
-      return {name: 'Node', params: {address: this.item.node.stargate}}
+      return {name: 'Node', params: {nodeAddress: this.item.node.stargate}}
     },
     formattedType() {
       return this.item.node.type.charAt(0).toUpperCase() + this.item.node.type.slice(1)

--- a/src/components/StakeOverview.vue
+++ b/src/components/StakeOverview.vue
@@ -28,8 +28,10 @@
         <div class="stakeRow__value">{{ stake.type.slice(0, 1).toUpperCase() + stake.type.slice(1) }}</div>
       </div>
       <div class="stakeRow" v-if="stake.device">
-        <div class="stakeRow__label">Device</div>
-        <div class="stakeRow__value">{{ stake.device }}</div>
+        <div class="stakeRow__label">Node</div>
+        <div class="stakeRow__value">
+          <router-link :to="{name: 'Node', params: {address: stake.device}}">{{ stake.device }}</router-link>
+        </div>
       </div>
       <div class="stakeRow">
         <div class="stakeRow__label">Amount</div>
@@ -44,8 +46,7 @@
 import { CheckCircleIcon, ClockIcon } from '@heroicons/vue/outline'
 import { InformationCircleIcon } from '@heroicons/vue/solid'
 import Tooltip from '@/components/Tooltip'
-import { fetchStakeHistory } from '../utils/api'
-const { formatXe } = require('@edge/wallet-utils')
+import { formatXe } from '@edge/wallet-utils'
 
 export default {
   name: "StakeOverview",

--- a/src/components/StakeOverview.vue
+++ b/src/components/StakeOverview.vue
@@ -30,7 +30,7 @@
       <div class="stakeRow" v-if="stake.device">
         <div class="stakeRow__label">Node</div>
         <div class="stakeRow__value">
-          <router-link :to="{name: 'Node', params: {address: stake.device}}">{{ stake.device }}</router-link>
+          <router-link :to="{name: 'Node', params: {nodeAddress: stake.device}}">{{ stake.device }}</router-link>
         </div>
       </div>
       <div class="stakeRow">

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -10,7 +10,7 @@
         />
         <!-- the wallet isn't part of the stake data, so can't be used to sort -->
         <th width="23%">Wallet</th>
-        <TableHeader width="20%" header="Device" :sortQuery="sortQuery"
+        <TableHeader width="20%" header="Node" :sortQuery="sortQuery"
           sortParam="device" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
@@ -27,7 +27,7 @@
         <th width="12%">ID</th>
         <th width="12%">Hash</th>
         <th width="23%">Wallet</th>
-        <th width="20%">Device</th>
+        <th width="20%">Node</th>
         <th width="8%">Type</th>
         <th width="8%">Status</th>
         <th class="amount-col" width="15%">Amount XE</th>

--- a/src/components/StakesTable.vue
+++ b/src/components/StakesTable.vue
@@ -3,10 +3,10 @@
     <thead class="hidden lg:table-header-group">
       <tr v-if="sortable">
         <TableHeader width="12%" header="ID" :sortQuery="sortQuery"
-          sortParam="id" :onSortingUpdate="updateSorting"
+          sortParam="id" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="12%" header="Hash" :sortQuery="sortQuery"
-          sortParam="hash" :onSortingUpdate="updateSorting"
+          sortParam="hash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <!-- the wallet isn't part of the stake data, so can't be used to sort -->
         <th width="23%">Wallet</th>
@@ -14,7 +14,7 @@
           sortParam="device" :onSortingUpdate="updateSorting"
         />
         <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
-          sortParam="type" :onSortingUpdate="updateSorting"
+          sortParam="type" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="8%" header="Status" :sortQuery="sortQuery"
           sortParam="released,unlockRequested" :onSortingUpdate="updateSorting"

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -32,32 +32,32 @@
     </td>
 
     <td data-title="Type:">
-      <span class="monospace md:font-sans">{{ formattedType }}</span>
+      <span class="monospace md:font-sans md:inline-block">{{ formattedType }}</span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="item.released">
+      <span v-if="item.released" class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ArrowCircleDownIcon/></span>
         <span class="monospace md:font-sans">Released</span>
       </span>
-      <span v-else-if="item.unlockRequested">
+      <span v-else-if="item.unlockRequested" class="md:inline-block">
         <span v-if="isUnlocking">
           <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
           <span class="monospace md:font-sans">Unlocking</span>
         </span>
-        <span v-else>
+        <span v-else class="md:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><DotsCircleHorizontalIcon/></span>
           <span class="monospace md:font-sans">Unlocked</span>
         </span>
       </span>
-      <span v-else>
+      <span v-else class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon/></span>
         <span class="monospace md:font-sans">Active</span>
       </span>
     </td>
 
-    <td data-title="Amount (XE):" class="amount-col">
-      <span class="monospace">{{ formattedAmount }}</span>
+    <td data-title="Amount (XE):" class="amount-col" :title="formattedAmount">
+      <span class="monospace md:inline-block">{{ formattedAmount }}</span>
     </td>
   </tr>
 </template>
@@ -103,7 +103,7 @@ export default {
 
 <style scoped>
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-none;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td span {
@@ -140,12 +140,12 @@ td .icon-grey {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -157,7 +157,7 @@ td a {
   }
 
   td:last-child {
-    @apply pb-13 border-b-2;
+    @apply pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -83,7 +83,7 @@ export default {
       else return 'Unlock'
     },
     nodeRoute() {
-      return {name: 'Node', params: {address: this.item.device}}
+      return {name: 'Node', params: {nodeAddress: this.item.device}}
     },
     stakeRoute() {
       return {name: 'Stake', params: {stakeId: this.item.id}}

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -22,12 +22,12 @@
       </router-link>
     </td>
 
-    <td data-title="Device:" :title="item.device">
-      <span v-if="item.device">
+    <td data-title="Node:" :title="item.device">
+      <router-link :to="nodeRoute" v-if="item.device">
         <span class="monospace md:inline-block">
           {{ item.device }}
         </span>
-      </span>
+      </router-link>
       <span v-else class="text-gray-400">None</span>
     </td>
 
@@ -81,6 +81,9 @@ export default {
       if (this.item.released) return null
       else if (this.item.unlockRequested) return 'Release'
       else return 'Unlock'
+    },
+    nodeRoute() {
+      return {name: 'Node', params: {address: this.item.device}}
     },
     stakeRoute() {
       return {name: 'Stake', params: {stakeId: this.item.id}}

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -25,6 +25,7 @@ export default {
     'classes',
     'header',
     'onSortingUpdate',
+    'sortAscFirst',
     'sortQuery',
     'sortParam',
     'width'
@@ -65,19 +66,36 @@ export default {
     updateSorting() {
       // sorting logic is:
       // - if param already at front of list, toggle between descending > ascending > remove > descending
+      // (if sortAscFirst = true, order is ascending > descending > remove > ascending)
       // - if param already in sorting list, bring to front (as descending)
       // - if param not in list, add to front of list (as descending)
-      if (!this.sortQuery) this.onSortingUpdate(this.sortParamDesc)
-      else if (this.startRegex.test(this.sortQuery)) {
-        let replaceString = this.sortParam
-        if (!this.fullRegex.test(this.sortQuery)) replaceString += ','
-        if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(this.startRegex, replaceString))
-        else this.onSortingUpdate(this.sortQuery.replace(this.startRegex, ''))
+      if (!this.sortAscFirst) {
+        if (!this.sortQuery) this.onSortingUpdate(this.sortParamDesc)
+          else if (this.startRegex.test(this.sortQuery)) {
+            let replaceString = this.sortParam
+            if (!this.fullRegex.test(this.sortQuery)) replaceString += ','
+            if (this.sortQuery[0] === '-') this.onSortingUpdate(this.sortQuery.replace(this.startRegex, replaceString))
+            else this.onSortingUpdate(this.sortQuery.replace(this.startRegex, ''))
+          }
+          else {
+            let newSortQuery = this.sortParamDesc
+            if (this.sortQuery) newSortQuery += `,${this.sortQuery.replace(this.midRegex, '').replace(/,$/, '')}`
+            this.onSortingUpdate(newSortQuery)
+          }
       }
       else {
-        let newSortQuery = this.sortParamDesc
-        if (this.sortQuery) newSortQuery += `,${this.sortQuery.replace(this.midRegex, '').replace(/,$/, '')}`
-        this.onSortingUpdate(newSortQuery)
+        if (!this.sortQuery) this.onSortingUpdate(this.sortParam)
+        else if (this.startRegex.test(this.sortQuery)) {
+          let replaceString = this.sortParamDesc
+          if (!this.fullRegex.test(this.sortQuery)) replaceString += ','
+          if (this.sortQuery[0] !== '-') this.onSortingUpdate(this.sortQuery.replace(this.startRegex, replaceString))
+          else this.onSortingUpdate(this.sortQuery.replace(this.startRegex, ''))
+        }
+        else {
+          let newSortQuery = this.sortParam
+          if (this.sortQuery) newSortQuery += `,${this.sortQuery.replace(this.midRegex, '').replace(/,$/, '')}`
+          this.onSortingUpdate(newSortQuery)
+        }
       }
     }
   }

--- a/src/components/TransactionsTable.vue
+++ b/src/components/TransactionsTable.vue
@@ -7,17 +7,17 @@
             sortParam="timestamp" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="15%" header="Tx Hash" :sortQuery="sortQuery"
-            sortParam="hash" :onSortingUpdate="updateSorting"
+            sortParam="hash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="15%" header="From" :sortQuery="sortQuery"
-            sortParam="sender" :onSortingUpdate="updateSorting"
+            sortParam="sender" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <th width="2%" class="hidden lg:table-cell">&nbsp;</th>
           <TableHeader width="15%" header="To" :sortQuery="sortQuery"
-            sortParam="recipient" :onSortingUpdate="updateSorting"
+            sortParam="recipient" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="25%" header="Memo" :sortQuery="sortQuery"
-            sortParam="data.memo" :onSortingUpdate="updateSorting"
+            sortParam="data.memo" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="10%" header="Status" :sortQuery="sortQuery"
             sortParam="block.height" :onSortingUpdate="updateSorting"
@@ -43,10 +43,10 @@
             sortParam="timestamp" :onSortingUpdate="updateSorting"
           />
           <TableHeader width="10%" header="Tx Hash" :sortQuery="sortQuery"
-            sortParam="hash" :onSortingUpdate="updateSorting"
+            sortParam="hash" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="30%" header="From/To" :sortQuery="sortQuery"
-            sortParam="sortAddress" :onSortingUpdate="updateSorting"
+            sortParam="sortAddress" :onSortingUpdate="updateSorting" :sortAscFirst="true"
           />
           <TableHeader width="25%" header="Memo" :sortQuery="sortQuery"
             sortParam="data.memo" :onSortingUpdate="updateSorting"

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,9 +1,9 @@
 <template>
   <tr v-if="!wallet" :class="item.pending && 'pending'">
     <td data-title="Date:" :title="date">
-      <div class="overflow"><span class="overflow">
+      <span class="md:inline-block">
         {{ date }}
-      </span></div>
+      </span>
     </td>
 
     <td data-title="Tx Hash:" :title="item.hash">
@@ -23,7 +23,7 @@
     </td>
 
     <td>
-      <span class="mr-1 -mt-2 icon icon-green"><ArrowRightIcon /></span>
+      <span class="mr-1 -mt-2 icon icon-green md:inline-block"><ArrowRightIcon /></span>
     </td>
 
     <td data-title="To:" :title="item.recipient">
@@ -35,24 +35,24 @@
     </td>
 
     <td data-title="Memo:" :title="item.data.memo || 'None'">
-      <div class="overflow"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
+      <span class="md:inline-block"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
         {{ item.data.memo || 'None'}}
-      </span></div>
+      </span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="isConfirmed">
+      <span v-if="isConfirmed" class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
         <span class="monospace md:font-sans">{{ statusFormatted }}</span>
       </span>
-      <span v-else>
+      <span v-else class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
         <span class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col">
-      <span class="monospace">
+      <span class="monospace md:inline-block">
         {{ formattedAmount }}
       </span>
     </td>
@@ -74,21 +74,21 @@
       </router-link>
     </td>
 
-    <td v-if="sent" data-title="To:">
-      <span class="icon-wrap">
-        <span class="mr-1 -mt-2 icon icon-red"><ArrowUpIcon /></span>
+    <td v-if="sent" data-title="To:" class="from-to" :title="item.recipient">
+      <span>
+        <span class="icon-wrap"><ArrowUpIcon class="icon inline-icon icon-red"/></span>
         <router-link :to="toAddressRoute">
-          <span class="monospace md:inline-block">
+          <span class="monospace lg:inline-block">
             {{ item.recipient }}
           </span>
         </router-link>
       </span>
     </td>
-    <td v-else data-title="From:">
-      <span class="icon-wrap">
-        <span class="mr-1 -mt-2 icon icon-green"><ArrowDownIcon /></span>
+    <td v-else data-title="From:" class="from-to" :title="item.sender">
+      <span>
+        <span class="icon-wrap"><ArrowDownIcon class="icon inline-icon icon-green"/></span>
         <router-link :to="fromAddressRoute">
-          <span class="monospace md:inline-block">
+          <span class="monospace lg:inline-block">
             {{ item.sender }}
           </span>
         </router-link>
@@ -96,24 +96,24 @@
     </td>
 
     <td data-title="Memo:" :title="item.data.memo || 'None'">
-      <div class="overflow"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
+      <span class="md:inline-block"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
         {{ item.data.memo || 'None'}}
-      </span></div>
+      </span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="isConfirmed">
+      <span v-if="isConfirmed" class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
         <span class="monospace md:font-sans">{{ statusFormatted }}</span>
       </span>
-      <span v-else>
+      <span v-else class="md:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
         <span class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
       </span>
     </td>
 
-    <td data-title="Amount (XE):" class="amount-col">
-      <span class="monospace">
+    <td data-title="Amount (XE):" class="amount-col" :title="`${sent ? '-' : ''}${formattedAmount}`">
+      <span class="monospace md:inline-block">
         {{ `${sent ? '-' : ''}${formattedAmount}` }}
       </span>
     </td>
@@ -185,10 +185,6 @@ td a {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
-td .overflow {
-  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
-}
-
 td::before {
   content: attr(data-title);
   @apply font-normal mr-8 min-w-100 text-xs text-gray-600 pt-2;
@@ -206,6 +202,10 @@ td .icon {
   @apply w-15 inline-block align-middle;
 }
 
+td .inline-icon {
+  @apply inline-block mb-2 lg:mb-0
+}
+
 td .icon-green {
   @apply text-green;
 }
@@ -218,12 +218,8 @@ td .icon-red {
   @apply text-red;
 }
 
-.icon-wrap {
-  @apply flex overflow-ellipsis overflow-hidden whitespace-nowrap;
-}
-
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
 }
 
 tr.pending {
@@ -234,9 +230,17 @@ tr.pending a {
   @apply italic text-gray-400;
 }
 
+td.from-to span {
+  @apply lg:w-11/12;
+}
+
+.icon-wrap {
+  @apply max-w-max
+}
+
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td:first-child {
@@ -244,11 +248,11 @@ tr.pending a {
   }
 
   td.amount-col {
-    @apply text-right;
+    @apply text-right pr-30;
   }
 
   td:last-child {
-    @apply pr-30 pb-13 text-right border-b-2;
+    @apply pb-10 border-b-2;
   }
 
   td:before {

--- a/src/components/WalletSummary.vue
+++ b/src/components/WalletSummary.vue
@@ -25,7 +25,7 @@ export default {
         let summary = `The wallet with address <span class="emphasis word-break">${this.wallet.address}</span> has a balance of <span class="emphasis">${this.formatAmount(this.wallet.balance)}</span> XE. `
         summary += `It has <span class="emphasis">${this.wallet.txCount.toLocaleString()}</span> ${this.wallet.txCount === 1 ? 'transaction' : 'transactions'} associated with it. `
         if (this.wallet.staked) {
-          summary += `It has <span class="emphasis">${this.wallet.stakeCount}</span> ${this.stakeCount === 1 ? 'stake' : 'stakes'} with a total value of <span class="emphasis">${this.formatAmount(this.wallet.staked)}</span> XE. `
+          summary += `It has <span class="emphasis">${this.wallet.stakeCount}</span> ${this.wallet.stakeCount === 1 ? 'stake' : 'stakes'} with a total value of <span class="emphasis">${this.formatAmount(this.wallet.staked)}</span> XE. `
         }
         summary += `The nonce is <span class="emphasis">${this.wallet.nonce}</span>. `
 

--- a/src/components/WalletsTable.vue
+++ b/src/components/WalletsTable.vue
@@ -4,7 +4,7 @@
       <thead class="sticky top-0 z-10 hidden lg:table-header-group">
       <tr>
         <TableHeader width="30%" header="Address" :sortQuery="sortQuery"
-          sortParam="address" :onSortingUpdate="updateSorting"
+          sortParam="address" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <th width="16%">Latest Tx</th>
         <TableHeader width="8%" header="Txs" :sortQuery="sortQuery"

--- a/src/components/WalletsTableItem.vue
+++ b/src/components/WalletsTableItem.vue
@@ -1,9 +1,10 @@
 <template>
   <tr>
-    <td data-title="Address:" :title="item.address" class="address">
+    <td data-title="Address:" :title="item.address">
       <router-link :to="addressRoute">
         <span class="monospace md:inline-block">{{ item.address }}</span>
-      </router-link><BadgeCheckIcon v-if="item.trusted" class="trusted" />
+      </router-link>
+      <span class="icon-wrap"><BadgeCheckIcon v-if="item.trusted" class="trusted" /></span>
     </td>
 
     <td data-title="Latest Tx:">
@@ -13,19 +14,19 @@
     </td>
 
     <td data-title="Transactions:">
-      <span class="monospace">{{ txCountFormatted }}</span>
+      <span class="monospace md:inline-block">{{ txCountFormatted }}</span>
     </td>
 
     <td data-title="Stakes:">
-      <span class="monospace">{{ stakeCountFormatted }}</span>
+      <span class="monospace md:inline-block">{{ stakeCountFormatted }}</span>
     </td>
 
     <td data-title="Staked XE:" class="amount-col">
-      <span class="monospace">{{ stakedFormatted }}</span>
+      <span class="monospace md:inline-block">{{ stakedFormatted }}</span>
     </td>
 
     <td data-title="Balance (XE):" class="amount-col">
-      <span class="monospace">{{ balanceFormatted }}</span>
+      <span class="monospace md:inline-block">{{ balanceFormatted }}</span>
     </td>
   </tr>
 </template>
@@ -73,7 +74,7 @@ export default {
 
 <style scoped>
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-none;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td::before {
@@ -92,9 +93,6 @@ td:last-child {
 td .icon {
   @apply w-15 inline-block align-middle;
 }
-td .icon--confirmed {
-  @apply w-16 md:w-18;
-}
 
 td .icon-green {
   @apply text-green;
@@ -108,33 +106,29 @@ td .icon-red {
   @apply text-red;
 }
 
-td.arrow-icon {
-  @apply hidden lg:table-cell;
-}
-
-td.arrow-icon svg {
-  @apply pt-px w-14 h-14 text-green;
-}
-
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
 td a {
   @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
-td span {
-  @apply max-w-max w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
+.trusted {
+  @apply w-18 h-18 inline-block ml-2 text-green mb-2 lg:mb-0;
 }
 
-.trusted {
-  @apply w-18 h-18 inline-block ml-2 text-green;
+.icon-wrap {
+  @apply max-w-max
 }
 
 @screen lg {
   td {
-    @apply border-gray-200 pt-13 pb-15 table-cell border-b-2 align-middle;
+    @apply border-gray-200 pt-13 pb-10 table-cell border-b-2 align-middle;
   }
 
   td span {
@@ -146,7 +140,7 @@ td span {
   }
 
   td:last-child {
-    @apply pr-30 pb-13 text-right border-b-2;
+    @apply pr-30 pb-10 text-right border-b-2;
   }
 
   td.amount-col {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,7 +33,7 @@ const routes = [
     component: Nodes
   },
   {
-    path: '/node/:address',
+    path: '/node/:nodeAddress',
     name: 'Node',
     component: Nodes
   },

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -132,6 +132,10 @@ export default {
         const stargate = await index.session.session(process.env.VUE_APP_INDEX_API_URL, session.node.stargate)
         session.stargate = stargate
       }
+      // add wallet address to node data
+      const stake = await index.stake.stake(process.env.VUE_APP_INDEX_API_URL, session.node.stake)
+      session.node.wallet = stake.wallet
+
       this.session = session
 
       this.loaded = true

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -11,7 +11,7 @@
             <NodeSummary :session="session" />
           </div>
       </div>
-      <div v-else-if="!$route.params.address" class="container">
+      <div v-else-if="!$route.params.nodeAddress" class="container">
         <NodesTable
           :limit="limit"
           :receiveMetadata="onSessionsUpdate"
@@ -79,7 +79,7 @@ export default {
     NodesTable,
   },
   mounted() {
-    if (this.$route.params.address) { 
+    if (this.$route.params.nodeAddress) { 
       this.updateSession()
       // initiate polling
       this.iSession = setInterval(() => {
@@ -95,10 +95,10 @@ export default {
   },
   computed: {
     address() {
-      return this.$route.params.address || null
+      return this.$route.params.nodeAddress || null
     },
     baseRoute() {
-      return this.$route.params.address ? 'Node' : 'Nodes'
+      return this.$route.params.nodeAddress ? 'Node' : 'Nodes'
     },
     currentPage() {
       return Math.max(1, parseInt(this.$route.query.page) || 1)

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -30,9 +30,9 @@
         <div v-if="!loading" class="flex flex-col items-center justify-center h-full">
           <h1 class="m-0 mt-20 text-2xl font-bold">This node doesn't exist</h1>
           <p class="mt-5 mb-0 text-center monospace">
-            Try searching for a different node, or <router-link to="/network" class="underline hover:text-green">view all nodes</router-link>.
+            Try searching for a different node, or <router-link to="/nodes" class="underline hover:text-green">view all nodes</router-link>.
           </p>
-          <router-link to="/network">
+          <router-link to="/nodes">
             <a class="mt-20 button button--solid">View all nodes</a>
           </router-link>
         </div>
@@ -117,10 +117,18 @@ export default {
     async updateSession() {
       if (!this.address) return
       this.loading = true
-      const session = await index.session.session(
-        process.env.VUE_APP_INDEX_API_URL,
-        this.address
-      )
+      try {
+        const session = await index.session.session(
+          process.env.VUE_APP_INDEX_API_URL,
+          this.address
+        )
+      } catch (e) {
+        this.session = null
+        clearInterval(this.iSession)
+        this.loaded = true
+        this.loading = false
+        return
+      }
       // add gateway (if host) and stargate (if host/gateway) data to the node data
       if (session.node.type === 'host') {
         const gateway = await index.session.session(process.env.VUE_APP_INDEX_API_URL, session.node.gateway)


### PR DESCRIPTION
- tables all aligned and set to same tr height
- links from stake device to node
- sort node location by country first, then city 
- added prop to table headers `sortAscFirst`, mostly used when wanting to sort alphabetically because we want a first, but with numbers we want highest first
- add wallet to node overview
- set map to correct height (same as stats block when full screen, or full width when mobile view)
- added border radius to map