### PR TITLE
Fix/misc fixes 17 03

### DIFF
--- a/src/components/BlocksTableItem.vue
+++ b/src/components/BlocksTableItem.vue
@@ -2,7 +2,7 @@
   <tr>
     <td data-title="Height:">
       <router-link :to="blockHeightRoute">
-        <span class="monospace md:inline-block max-w-max">
+        <span class="monospace lg:inline-block max-w-max">
           {{ item.height }}
         </span>
       </router-link>
@@ -10,34 +10,34 @@
 
     <td data-title="Block Hash:" :title="item.hash">
       <router-link :to="blockHashRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.hash }}
         </span>
       </router-link>
     </td>
 
     <td data-title="Data Hash:" :title="item.dataHash">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ item.dataHash }}
       </span>
     </td>
 
     <td data-title="Ledger Hash:" :title="item.ledgerHash">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ item.ledgerHash }}
       </span>
     </td>
 
     <td data-title="Transactions:">
-      <span class="monospace md:inline-block">{{ item.txCount }}</span>
+      <span class="monospace lg:inline-block">{{ item.txCount }}</span>
     </td>
 
-    <td data-title="XE:" class="monospace amount-col" :title="formattedTotal">
-      <span class="md:inline-block">{{ formattedTotal }}</span>
+    <td data-title="XE:" class="amount-col" :title="formattedTotal">
+      <span class="lg:inline-block monospace">{{ formattedTotal }}</span>
     </td>
 
     <td data-title="Mined:" :title="timeSince">
-      <span class="md:inline-block">
+      <span class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
         <span class="lg:text-gray-400 monospace lg:font-sans">
           {{ timeSince }}

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -2,7 +2,7 @@
   <tr>
     <td data-title="Address:" :title="item.node.address">
       <router-link :to="addressRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.node.address }}
         </span>
       </router-link>
@@ -10,57 +10,57 @@
 
     <td data-title="Gateway:" :title="item.node.gateway">
       <router-link v-if="item.node.gateway" :to="gatewayRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.node.gateway }}
         </span>
       </router-link>
-      <span v-else class="monospace md:inline-block text-gray">
+      <span v-else class="monospace lg:inline-block text-gray">
         N/A
       </span>
     </td>
 
     <td data-title="Stargate:" :title="item.node.stargate">
       <router-link v-if="item.node.stargate" :to="stargateRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.node.stargate }}
         </span>
       </router-link>
-      <span v-else class="monospace md:inline-block text-gray">
+      <span v-else class="monospace lg:inline-block text-gray">
         N/A
       </span>
     </td>
 
     <td data-title="Type:">
-      <span class="monospace md:font-sans md:inline-block">{{ formattedType }}</span>
+      <span class="monospace lg:font-sans lg:inline-block">{{ formattedType }}</span>
     </td>
 
     <td data-title="Location:" :title="location">
-      <span class="md:inline-block"><span class="monospace md:font-sans" :class="location === 'Unknown' && 'text-gray'">
+      <span class="lg:inline-block"><span class="monospace lg:font-sans" :class="location === 'Unknown' && 'text-gray'">
         {{ location }}
       </span></span>
     </td>
 
     <td data-title="Availability:">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ (item.availability * 100).toFixed(2) }}%
       </span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="isOnline" class="md:inline-block">
+      <span v-if="isOnline" class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><StatusOnlineIcon /></span>
-        <span class="monospace md:font-sans">Online</span>
+        <span class="monospace lg:font-sans">Online</span>
       </span>
-      <span v-else class="md:inline-block">
+      <span v-else class="lg:inline-block">
         <span class="mr-1 lg:-mt-2 icon icon-grey"><StatusOfflineIcon /></span>
-        <span class="monospace md:font-sans text-gray">Offline</span>
+        <span class="monospace lg:font-sans text-gray">Offline</span>
       </span>
     </td>
 
     <td data-title="Last Seen:">
-      <span class="md:inline-block">
+      <span class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
-        <span class="monospace md:font-sans text-gray">{{ lastActive }}</span>
+        <span class="monospace lg:font-sans text-gray">{{ lastActive }}</span>
       </span>
     </td>
   </tr>

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -60,7 +60,7 @@ export default {
   props: ['blocks', 'loading'],
   methods: {
     formatAmount(amount) {
-      return formatXe(amount, true)
+      return formatXe(amount / 1e6, true)
     },
     timeSince(ts) {
       return moment(ts).fromNow()

--- a/src/components/RecentBlocks.vue
+++ b/src/components/RecentBlocks.vue
@@ -6,10 +6,10 @@
       <thead class="hidden lg:table-header-group">
         <tr>
           <th width="15%">Height</th>
-          <th>Hash</th>
-          <th>Txs</th>
-          <th>Total XE</th>
-          <th>Mined</th>
+          <th width="20%">Hash</th>
+          <th width="10%">Txs</th>
+          <th width="25%" class="amount-col">Total XE</th>
+          <th width="30%">Mined</th>
         </tr>
       </thead>
       <tbody v-if="loading">
@@ -28,20 +28,21 @@
           </td>
           <td class="" data-title="Hash:">
             <router-link :to="{name: 'Block', params: {blockId: block.hash}}">
-              <span class="hidden monospace md:inline-block">{{ block.hash.substr(0, 16) }}…</span>
-              <span class="monospace md:hidden">{{ block.hash.substr(0, 16) }}…</span>
+              <span class="monospace lg:inline-block">{{ block.hash }}…</span>
             </router-link>
           </td>
           <td data-title="Txs:">
-            {{ block.transactions.length }}
+            <span class="monospace lg:inline-block">{{ block.transactions.length }}</span>
           </td>
-          <td data-title="Total XE:" class="monospace">
-            {{ formatAmount(block.total) }}
+          <td data-title="Total XE:" class="amount-col">
+            <span class="monospace lg:inline-block">{{ formatAmount(block.total) }}</span>
           </td>
-          <td class="truncate" data-title="Mined:">
-            <span class="mr-1 lg:-mt-2 icon"><ClockIcon /></span>
-            <span class="truncate monospace md:font-sans md:text-gray-400">
-              {{ timeSince(block.timestamp) }}
+          <td data-title="Mined:">
+            <span class="lg:inline-block">
+              <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon /></span>
+              <span class="monospace lg:font-sans lg:text-gray-400">
+                {{ timeSince(block.timestamp) }}
+              </span>
             </span>
           </td>
         </tr>
@@ -77,8 +78,16 @@ table, tbody, tr {
   @apply block;
 }
 
+table {
+  @apply w-full table-fixed
+}
+
 th {
   @apply font-normal text-sm2 text-left bg-gray-100 px-5 border-b-2 border-gray-200 py-8;
+}
+
+th.amount-col {
+  @apply text-right pr-30
 }
 
 /* th:first-child {
@@ -94,7 +103,7 @@ tr {
 }
 
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td::before {
@@ -111,7 +120,15 @@ td:last-child {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
+}
+
+td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
 td .icon {
@@ -145,6 +162,10 @@ td .icon {
 
   td:first-child {
     @apply pl-20 pt-13;
+  }
+
+  td.amount-col {
+    @apply text-right pr-30;
   }
 
   td:last-child {

--- a/src/components/RecentTransactions.vue
+++ b/src/components/RecentTransactions.vue
@@ -5,10 +5,10 @@
     <table class="w-full">
       <thead class="hidden lg:table-header-group">
         <tr>
-          <th>Hash</th>
-          <th>From</th>
-          <th><span class="pl-5">To</span></th>
-          <th class="right">Amount XE</th>
+          <th width="20%">Hash</th>
+          <th width="25%">From</th>
+          <th width="25%"><span class="pl-5">To</span></th>
+          <th width="30%" class="amount-col">Amount XE</th>
         </tr>
       </thead>
       <tbody v-if="loading">
@@ -22,26 +22,25 @@
         <tr v-for="transaction in transactions" :key="transaction.hash">
           <td data-title="Hash:">
             <router-link :to="{name: 'Transaction', params: {hash: transaction.hash}}">
-              <span class="monospace md:inline-block">{{ sliceString(transaction.hash, 12) }}</span>
-              <span class="monospace md:hidden">{{ sliceString(transaction.hash, 20) }}</span>
+              <span class="monospace lg:inline-block">{{ transaction.hash }}</span>
             </router-link>
           </td>
           <td data-title="From:">
             <router-link :to="{name: 'Wallet', params: {address: transaction.sender}}">
-              <span class="truncate monospace" :title="transaction.sender">
-                {{ sliceString(transaction.sender, 18) }}
+              <span class="monospace lg:inline-block" :title="transaction.sender">
+                {{ transaction.sender }}
               </span>
             </router-link>
           </td>
           <td data-title="To:" class="relative">
             <router-link :to="{name: 'Wallet', params: {address: transaction.recipient}}">
-              <span class="truncate lg:pl-5 monospace" :title="transaction.recipient">
-                {{ sliceString(transaction.recipient, 18) }}
+              <span class="lg:pl-5 lg:inline-block monospace" :title="transaction.recipient">
+                {{ transaction.recipient }}
               </span>
             </router-link>
           </td>
-          <td class="lg:text-right" data-title="Amount XE:">
-            <span class="monospace">
+          <td class="amount-col" data-title="Amount XE:">
+            <span class="monospace lg:inline-block">
               {{ formatAmount(transaction.amount) }}
             </span>
           </td>
@@ -63,9 +62,6 @@ export default {
     formatAmount(amount) {
       return formatXe(amount, true)
     },
-    sliceString(string, symbols) {
-      return string.length > symbols ? `${string.slice(0, symbols)}…` : string
-    },
     timeSince(ts) {
       return moment(ts).fromNow()
     }
@@ -81,11 +77,19 @@ table, tbody, tr {
   @apply block;
 }
 
+table {
+  @apply w-full table-fixed
+}
+
 th {
   @apply font-normal text-sm2 text-left bg-gray-100 px-5 border-b-2 border-gray-200 py-8;
 }
 th.right {
   @apply text-right;
+}
+
+th.amount-col {
+  @apply text-right pr-30
 }
 
 /* th:first-child {
@@ -97,7 +101,7 @@ th:last-child {
 }
 
 td {
-  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4;
+  @apply bg-white text-sm2 font-normal flex items-center px-5 break-all max-w-full pb-4 leading-tight;
 }
 
 td::before {
@@ -114,7 +118,15 @@ td:last-child {
 }
 
 td a {
-  @apply leading-none border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+  @apply border-b border-black border-opacity-25 hover:border-green hover:border-opacity-25 hover:text-green align-middle;
+}
+
+td span {
+  @apply w-full overflow-ellipsis overflow-hidden whitespace-nowrap;
+}
+
+td a {
+  @apply overflow-ellipsis overflow-hidden whitespace-nowrap;
 }
 
 td .arrow-icon {
@@ -144,6 +156,10 @@ td .arrow-icon {
 
   td {
     @apply border-gray-200 pt-13 pb-14 table-cell border-b-2 align-middle;
+  }
+
+  td.amount-col {
+    @apply text-right pr-30;
   }
 
   td:first-child {

--- a/src/components/StakesTableItem.vue
+++ b/src/components/StakesTableItem.vue
@@ -2,21 +2,21 @@
   <tr>
     <td data-title="ID:" :title="item.id">
       <router-link :to="stakeRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.id }}
         </span>
       </router-link>
     </td>
 
     <td data-title="Hash:" :title="item.hash">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ item.hash }}
       </span>
     </td>
 
     <td data-title="Wallet:" :title="item.tx.sender">
       <router-link :to="walletRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.tx.sender }}
         </span>
       </router-link>
@@ -24,7 +24,7 @@
 
     <td data-title="Node:" :title="item.device">
       <router-link :to="nodeRoute" v-if="item.device">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.device }}
         </span>
       </router-link>
@@ -32,32 +32,32 @@
     </td>
 
     <td data-title="Type:">
-      <span class="monospace md:font-sans md:inline-block">{{ formattedType }}</span>
+      <span class="monospace lg:font-sans lg:inline-block">{{ formattedType }}</span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="item.released" class="md:inline-block">
+      <span v-if="item.released" class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ArrowCircleDownIcon/></span>
-        <span class="monospace md:font-sans">Released</span>
+        <span class="monospace lg:font-sans">Released</span>
       </span>
-      <span v-else-if="item.unlockRequested" class="md:inline-block">
+      <span v-else-if="item.unlockRequested" class="lg:inline-block">
         <span v-if="isUnlocking">
           <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
-          <span class="monospace md:font-sans">Unlocking</span>
+          <span class="monospace lg:font-sans">Unlocking</span>
         </span>
-        <span v-else class="md:inline-block">
+        <span v-else class="lg:inline-block">
           <span class="mr-1 -mt-2 icon icon-grey"><DotsCircleHorizontalIcon/></span>
-          <span class="monospace md:font-sans">Unlocked</span>
+          <span class="monospace lg:font-sans">Unlocked</span>
         </span>
       </span>
-      <span v-else class="md:inline-block">
+      <span v-else class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon/></span>
-        <span class="monospace md:font-sans">Active</span>
+        <span class="monospace lg:font-sans">Active</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col" :title="formattedAmount">
-      <span class="monospace md:inline-block">{{ formattedAmount }}</span>
+      <span class="monospace lg:inline-block">{{ formattedAmount }}</span>
     </td>
   </tr>
 </template>

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -1,14 +1,14 @@
 <template>
   <tr v-if="!wallet" :class="item.pending && 'pending'">
     <td data-title="Date:" :title="date">
-      <span class="md:inline-block">
+      <span class="lg:inline-block">
         {{ date }}
       </span>
     </td>
 
     <td data-title="Tx Hash:" :title="item.hash">
       <router-link :to="txHashRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.hash }}
         </span>
       </router-link>
@@ -16,43 +16,43 @@
     
     <td data-title="From:" :title="item.sender">
       <router-link :to="fromAddressRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.sender }}
         </span>
       </router-link>
     </td>
 
-    <td>
-      <span class="mr-1 -mt-2 icon icon-green md:inline-block"><ArrowRightIcon /></span>
+    <td class="arrow-icon">
+      <span class="mr-1 -mt-2 icon icon-green lg:inline-block"><ArrowRightIcon /></span>
     </td>
 
     <td data-title="To:" :title="item.recipient">
       <router-link :to="toAddressRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.recipient }}
         </span>
       </router-link>
     </td>
 
     <td data-title="Memo:" :title="item.data.memo || 'None'">
-      <span class="md:inline-block"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
+      <span class="lg:inline-block"><span class="monospace lg:font-sans" :class="!item.data.memo && 'text-gray-400'">
         {{ item.data.memo || 'None'}}
       </span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="isConfirmed" class="md:inline-block">
+      <span v-if="isConfirmed" class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
-        <span class="monospace md:font-sans">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans">{{ statusFormatted }}</span>
       </span>
-      <span v-else class="md:inline-block">
+      <span v-else class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
-        <span class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans text-gray-400">{{ statusFormatted }}</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ formattedAmount }}
       </span>
     </td>
@@ -61,14 +61,14 @@
   <!--for tx table in wallet, display a single "from/to" column rather than separate from and to columns-->
   <tr v-else :class="item.pending && 'pending'">
     <td data-title="Date:">
-      <span class="md:inline-block">
+      <span class="lg:inline-block">
         {{ date }}
       </span>
     </td>
 
     <td data-title="Tx Hash:" :title="item.hash">
       <router-link :to="txHashRoute">
-        <span class="monospace md:inline-block">
+        <span class="monospace lg:inline-block">
           {{ item.hash }}
         </span>
       </router-link>
@@ -96,24 +96,24 @@
     </td>
 
     <td data-title="Memo:" :title="item.data.memo || 'None'">
-      <span class="md:inline-block"><span class="monospace md:font-sans" :class="!item.data.memo && 'text-gray-400'">
+      <span class="lg:inline-block"><span class="monospace lg:font-sans" :class="!item.data.memo && 'text-gray-400'">
         {{ item.data.memo || 'None'}}
       </span></span>
     </td>
 
     <td data-title="Status:">
-      <span v-if="isConfirmed" class="md:inline-block">
+      <span v-if="isConfirmed" class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-green"><CheckCircleIcon /></span>
-        <span class="monospace md:font-sans">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans">{{ statusFormatted }}</span>
       </span>
-      <span v-else class="md:inline-block">
+      <span v-else class="lg:inline-block">
         <span class="mr-1 -mt-2 icon icon-grey"><ClockIcon/></span>
-        <span class="monospace md:font-sans text-gray-400">{{ statusFormatted }}</span>
+        <span class="monospace lg:font-sans text-gray-400">{{ statusFormatted }}</span>
       </span>
     </td>
 
     <td data-title="Amount (XE):" class="amount-col" :title="`${sent ? '-' : ''}${formattedAmount}`">
-      <span class="monospace md:inline-block">
+      <span class="monospace lg:inline-block">
         {{ `${sent ? '-' : ''}${formattedAmount}` }}
       </span>
     </td>
@@ -216,6 +216,10 @@ td .icon-grey {
 
 td .icon-red {
   @apply text-red;
+}
+
+td.arrow-icon {
+  @apply lg:inline-block hidden
 }
 
 td a {

--- a/src/components/WalletsTableItem.vue
+++ b/src/components/WalletsTableItem.vue
@@ -2,31 +2,31 @@
   <tr>
     <td data-title="Address:" :title="item.address">
       <router-link :to="addressRoute">
-        <span class="monospace md:inline-block">{{ item.address }}</span>
+        <span class="monospace lg:inline-block">{{ item.address }}</span>
       </router-link>
       <span class="icon-wrap"><BadgeCheckIcon v-if="item.trusted" class="trusted" /></span>
     </td>
 
     <td data-title="Latest Tx:">
       <router-link :to="latestTxRoute">
-        <span class="monospace md:inline-block">{{ item.latestTransaction.hash }}</span>
+        <span class="monospace lg:inline-block">{{ item.latestTransaction.hash }}</span>
       </router-link>
     </td>
 
     <td data-title="Transactions:">
-      <span class="monospace md:inline-block">{{ txCountFormatted }}</span>
+      <span class="monospace lg:inline-block">{{ txCountFormatted }}</span>
     </td>
 
     <td data-title="Stakes:">
-      <span class="monospace md:inline-block">{{ stakeCountFormatted }}</span>
+      <span class="monospace lg:inline-block">{{ stakeCountFormatted }}</span>
     </td>
 
     <td data-title="Staked XE:" class="amount-col">
-      <span class="monospace md:inline-block">{{ stakedFormatted }}</span>
+      <span class="monospace lg:inline-block">{{ stakedFormatted }}</span>
     </td>
 
     <td data-title="Balance (XE):" class="amount-col">
-      <span class="monospace md:inline-block">{{ balanceFormatted }}</span>
+      <span class="monospace lg:inline-block">{{ balanceFormatted }}</span>
     </td>
   </tr>
 </template>

--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -130,8 +130,6 @@ export default {
     if (this.blockId) {
       this.fetchData()
     }
-    const p = parseInt(this.$route.query.page) || 0
-    if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
   },
   methods: {
     async fetchBlocks(options) {
@@ -183,7 +181,10 @@ export default {
   },
   watch:{
     metadata() {
-      // clamp pagination to available page numbers with automatic redirection
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -99,9 +99,6 @@ export default {
   mounted() {
     if (this.$route.params.stakeId) { 
       this.fetchData()
-    } else {
-      const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   computed: {
@@ -159,7 +156,10 @@ export default {
       this.fetchData()
     },
     metadata() {
-      // clamp pagination to available page numbers with automatic redirection
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -106,9 +106,6 @@ export default {
       this.fetchData().then(() => {
         this.pollData()
       })
-    } else {
-      const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   methods: {
@@ -166,7 +163,10 @@ export default {
       this.fetchData()
     },
     metadata() {
-      // clamp pagination to available page numbers with automatic redirection
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }
   }

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -153,14 +153,6 @@ export default {
     if (this.address) {
       this.fetchData()
       this.pollData()
-      // clamp tx and stakes tables to page 1
-      const txP = parseInt(this.$route.query.txsPage) || 0
-      const stakesP = parseInt(this.$route.query.stakesPage) || 0
-      if (txP < 1) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
-      if (stakesP < 1) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
-    } else {
-      const p = parseInt(this.$route.query.page) || 0
-      if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
     }
   },
   methods: {
@@ -208,15 +200,24 @@ export default {
       this.fetchData()
     },
     metadata() {
-      // clamp wallets pagination to available page numbers with automatic redirection
+      if (this.lastPage > 1) {
+        const p = parseInt(this.$route.query.page) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     },
     stakesMetadata() {
-      // clamp stakes pagination to available page numbers with automatic redirection
+      if (this.stakesLastPage > 1) {
+        const p = parseInt(this.$route.query.stakesPage) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
+      }
       if (this.stakesCurrentPage > this.stakesLastPage) this.$router.replace({ query: { ...this.$route.query, stakesPage: this.stakesLastPage } })
     },
     txsMetadata() {
-      // clamp tx pagination to available page numbers with automatic redirection
+      if (this.txsLastPage > 1) {
+        const p = parseInt(this.$route.query.txsPage) || 0
+        if (p < 1) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
+      }
       if (this.txsCurrentPage > this.txsLastPage) this.$router.replace({ query: { ...this.$route.query, txsPage: this.txsLastPage } })
     }
   }


### PR DESCRIPTION
- page clamping to page 1 only occurs if there are more than 1 pages
- recent block formats amounts correctly
- style both recent blocks and recent transactions tables so they are more consistent with rest of explorer
- make sure when a table collapses (at lg screen size), all effects happen at same point - before some happened at lg, others at md size