### PR TITLE
fix: display correct tx count and total xe for a block

### DIFF
--- a/src/components/BlockOverview.vue
+++ b/src/components/BlockOverview.vue
@@ -42,7 +42,7 @@
       </div>
       <div class="transactionRow">
         <div class="transactionRow__label">Transactions</div>
-        <div class="transactionRow__value">{{ block.transactions.length }}</div>
+        <div class="transactionRow__value">{{ block.txCount }}</div>
       </div>
       <div class="transactionRow">
         <div class="transactionRow__label">Total XE</div>

--- a/src/components/BlockSummary.vue
+++ b/src/components/BlockSummary.vue
@@ -8,7 +8,7 @@
         No transactions were sent in this block.
       </span>
       <span v-else>
-        A total of <span class="emphasis">{{ formatAmount(block.total) }} XE</span> was sent in this block over <span class="emphasis">{{ block.transactions.length.toLocaleString() }}</span> {{ block.transactions.length === 1 ? 'transaction' : 'transactions' }} with an average value of <span class="emphasis">{{ formatAmount(block.average) }} XE</span>.
+        A total of <span class="emphasis">{{ formatAmount(block.total) }} XE</span> was sent in this block over <span class="emphasis">{{ block.txCount.toLocaleString() }}</span> {{ block.txCount === 1 ? 'transaction' : 'transactions' }} with an average value of <span class="emphasis">{{ formatAmount(block.average) }} XE</span>.
       </span>
 
       The block nonce was <span class="emphasis">{{ block.nonce }}</span>.

--- a/src/components/TransactionsTableItem.vue
+++ b/src/components/TransactionsTableItem.vue
@@ -114,7 +114,7 @@
 
     <td data-title="Amount (XE):" class="amount-col" :title="`${sent ? '-' : ''}${formattedAmount}`">
       <span class="monospace lg:inline-block">
-        {{ `${sent ? '-' : ''}${formattedAmount}` }}
+        {{ `${sent && formattedAmount > 0 ? '-' : ''}${formattedAmount}` }}
       </span>
     </td>
   </tr>


### PR DESCRIPTION
Needs https://github.com/edge/index/pull/133 merged before it'll work

(I also sneaked in a quick fix for sent txs of value 0xe, which were previously showing as -0.00000)