### PR TITLE
fix: remove page 1 redirect unless page is less than 1

### DIFF
--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -181,9 +181,9 @@ export default {
   },
   watch:{
     metadata() {
-      if (this.$route.query.page < 1) {
-        const p = parseInt(this.$route.query.page) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.page) {
+        if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }

--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -181,7 +181,7 @@ export default {
   },
   watch:{
     metadata() {
-      if (this.lastPage > 1) {
+      if (this.$route.query.page < 1) {
         const p = parseInt(this.$route.query.page) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -152,9 +152,9 @@ export default {
       this.updateSession()
     },
     metadata() {
-      if (this.$route.query.page < 1) {
-        const p = parseInt(this.$route.query.page) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.page) {
+        if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -152,7 +152,7 @@ export default {
       this.updateSession()
     },
     metadata() {
-      if (this.lastPage > 1) {
+      if (this.$route.query.page < 1) {
         const p = parseInt(this.$route.query.page) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -156,7 +156,7 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.lastPage > 1) {
+      if (this.$route.query.page < 1) {
         const p = parseInt(this.$route.query.page) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }

--- a/src/views/Stakes.vue
+++ b/src/views/Stakes.vue
@@ -156,9 +156,9 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.$route.query.page < 1) {
-        const p = parseInt(this.$route.query.page) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.page) {
+        if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -163,7 +163,7 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.lastPage > 1) {
+      if (this.$route.query.page < 1) {
         const p = parseInt(this.$route.query.page) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -163,9 +163,9 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.$route.query.page < 1) {
-        const p = parseInt(this.$route.query.page) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.page) {
+        if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     }

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -87,6 +87,8 @@ import WalletsTable from "@/components/WalletsTable"
 import { checksumAddressIsValid } from '@edge/wallet-utils'
 import { fetchWallet } from '../utils/api'
 
+const numRegEx = /^[-+]?\d*$/
+
 export default {
   name: 'Wallets',
   title() {
@@ -200,21 +202,18 @@ export default {
       this.fetchData()
     },
     metadata() {
-      const numRegEx = /^[-+]?\d*$/
       if (this.$route.query.page) {
         if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     },
     stakesMetadata() {
-      const numRegEx = /^[-+]?\d*$/
       if (this.$route.query.stakesPage) {
         if (this.$route.query.stakesPage < 1 || !numRegEx.test(this.$route.query.stakesPage)) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
       }
       if (this.stakesCurrentPage > this.stakesLastPage) this.$router.replace({ query: { ...this.$route.query, stakesPage: this.stakesLastPage } })
     },
     txsMetadata() {
-      const numRegEx = /^[-+]?\d*$/
       if (this.$route.query.txsPage) {
         if (this.$route.query.txsPage < 1 || !numRegEx.test(this.$route.query.txsPage)) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
       }

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -200,23 +200,23 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.$route.query.page < 1) {
-        const p = parseInt(this.$route.query.page) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.page) {
+        if (this.$route.query.page < 1 || !numRegEx.test(this.$route.query.page)) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     },
     stakesMetadata() {
-      if (this.$route.query.stakesPage < 1) {
-        const p = parseInt(this.$route.query.stakesPage) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.stakesPage) {
+        if (this.$route.query.stakesPage < 1 || !numRegEx.test(this.$route.query.stakesPage)) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
       }
       if (this.stakesCurrentPage > this.stakesLastPage) this.$router.replace({ query: { ...this.$route.query, stakesPage: this.stakesLastPage } })
     },
     txsMetadata() {
-      if (this.$route.query.txsPage < 1) {
-        const p = parseInt(this.$route.query.txsPage) || 0
-        if (p < 1) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
+      const numRegEx = /^[-+]?\d*$/
+      if (this.$route.query.txsPage) {
+        if (this.$route.query.txsPage < 1 || !numRegEx.test(this.$route.query.txsPage)) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
       }
       if (this.txsCurrentPage > this.txsLastPage) this.$router.replace({ query: { ...this.$route.query, txsPage: this.txsLastPage } })
     }

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -200,21 +200,21 @@ export default {
       this.fetchData()
     },
     metadata() {
-      if (this.lastPage > 1) {
+      if (this.$route.query.page < 1) {
         const p = parseInt(this.$route.query.page) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, page: 1 } })
       }
       if (this.currentPage > this.lastPage) this.$router.replace({ query: { ...this.$route.query, page: this.lastPage } })
     },
     stakesMetadata() {
-      if (this.stakesLastPage > 1) {
+      if (this.$route.query.stakesPage < 1) {
         const p = parseInt(this.$route.query.stakesPage) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, stakesPage: 1 } })
       }
       if (this.stakesCurrentPage > this.stakesLastPage) this.$router.replace({ query: { ...this.$route.query, stakesPage: this.stakesLastPage } })
     },
     txsMetadata() {
-      if (this.txsLastPage > 1) {
+      if (this.$route.query.txsPage < 1) {
         const p = parseInt(this.$route.query.txsPage) || 0
         if (p < 1) this.$router.replace({ query: { ...this.$route.query, txsPage: 1 } })
       }


### PR DESCRIPTION
Now it only redirects to `?page=1` if someone manually enters non-numerical value, or a page number of < 1
Redirect to last page occurs if someone enters a value too high (as before, this isn't a change, just confirmation)