### PR TITLE
Fix/misc fixes 24 03

### DIFF
--- a/src/components/BlockSummary.vue
+++ b/src/components/BlockSummary.vue
@@ -8,7 +8,7 @@
         No transactions were sent in this block.
       </span>
       <span v-else>
-        A total of <span class="emphasis">{{ formatAmount(block.total) }} XE</span> was sent in this block over <span class="emphasis">{{ block.txCount.toLocaleString() }}</span> {{ block.txCount === 1 ? 'transaction' : 'transactions' }} with an average value of <span class="emphasis">{{ formatAmount(block.average) }} XE</span>.
+        A total of <span class="emphasis">{{ formatAmount(block.total) }} XE</span> was sent in this block over <span class="emphasis">{{ block.txCount.toLocaleString() }}</span> {{ block.txCount === 1 ? 'transaction' : 'transactions' }}<span v-if="block.txCount > 1"> with an average value of <span class="emphasis">{{ formatAmount(block.average) }} XE</span></span>.
       </span>
 
       The block nonce was <span class="emphasis">{{ block.nonce }}</span>.

--- a/src/components/BlockSummary.vue
+++ b/src/components/BlockSummary.vue
@@ -4,7 +4,7 @@
     <div class="relative max-h-full tile md:pr-50">
       Block <span class="emphasis">{{ block.height }}</span> was mined on <span class="emphasis">{{new Date(block.timestamp).toLocaleString().split(',')[0]}}</span> at <span class="emphasis">{{new Date(block.timestamp).toLocaleString().split(',')[1]}}</span>.
 
-      <span v-if="block.total == 0">
+      <span v-if="!block.txCount">
         No transactions were sent in this block.
       </span>
       <span v-else>

--- a/src/components/NodeOverview.vue
+++ b/src/components/NodeOverview.vue
@@ -27,13 +27,13 @@
         <div class="nodeRow__label">Address</div>
         <div class="nodeRow__value">{{ session.node.address }}</div>
       </div>
-      <div class="nodeRow" v-if="session.gateway">
+      <div class="nodeRow" v-if="isOnline && session.gateway">
         <div class="nodeRow__label">Gateway</div>
         <div class="nodeRow__value">
           <router-link :to="gatewayRoute">{{ session.gateway.node.address }}</router-link>
         </div>
       </div>
-      <div class="nodeRow" v-if="session.stargate">
+      <div class="nodeRow" v-if="isOnline && session.stargate">
         <div class="nodeRow__label">Stargate</div>
         <div class="nodeRow__value">
           <router-link  :to="stargateRoute">{{ session.stargate.node.address }}</router-link>

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -9,7 +9,7 @@
     </td>
 
     <td data-title="Gateway:" :title="item.node.gateway">
-      <router-link v-if="item.node.gateway" :to="gatewayRoute">
+      <router-link v-if="isOnline && item.node.gateway" :to="gatewayRoute">
         <span class="monospace lg:inline-block">
           {{ item.node.gateway }}
         </span>
@@ -20,7 +20,7 @@
     </td>
 
     <td data-title="Stargate:" :title="item.node.stargate">
-      <router-link v-if="item.node.stargate" :to="stargateRoute">
+      <router-link v-if="isOnline && item.node.stargate" :to="stargateRoute">
         <span class="monospace lg:inline-block">
           {{ item.node.stargate }}
         </span>

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -45,8 +45,7 @@ const fetchBlocks = async ({ blockId, options = {} }) => {
         const block = { ...results }
 
         // Add average XE.
-        block.average = block.transactions.length ? block.total / block.transactions.length : 0
-        block.average = block.average.toFixed(6)
+        block.average = block.txCount ? parseInt(block.total / block.txCount) : 0
         
         return {
           blocks: [block],


### PR DESCRIPTION
- removed average tx value from block summary where block has 1 tx only
- correct average tx value (was formatted incorrectly)
- change tx info in block summary to show even with 0xe amount
- display gateway/stargate as N/A for offline nodes (hide completely in NodeSummary)