### PR TITLE
feat: tweak node chart designs

### DIFF
--- a/src/components/NodeChartAvailability.vue
+++ b/src/components/NodeChartAvailability.vue
@@ -6,7 +6,6 @@
         :chart-options="chartOptions"
         :chart-data="chartData"
         :chart-id="'NodeAvailabilityChart'"
-        :width="width"
         :height="height"
       />
     </div>
@@ -64,6 +63,11 @@ export default {
             interaction: {
               mode: 'index',
               intersect: false,
+              callbacks: {
+                label: function(tooltipItem) {
+                  return tooltipItem.raw.toFixed(2) + ' %'
+                }
+              }
             }
           }
         }
@@ -96,4 +100,7 @@ export default {
 </script>
 
 <style scoped>
+.tile {
+  @apply flex-1 p-12 md:p-24 text-sm text-gray-300 bg-white rounded;
+}
 </style>

--- a/src/components/NodeChartDataInOut.vue
+++ b/src/components/NodeChartDataInOut.vue
@@ -6,7 +6,6 @@
         :chart-options="chartOptions"
         :chart-data="chartData"
         :chart-id="'NodeDataInOutChart'"
-        :width="width"
         :height="height"
       />
     </div>
@@ -26,15 +25,15 @@ export default {
         labels: this.timeSeries,
         datasets: [
           {
-            backgroundColor: 'rgb(255, 0, 0)',
-            borderColor: 'rgb(255, 0, 0)',
+            backgroundColor: 'rgb(255,138,138)',
+            borderColor: 'rgb(220, 60, 60)',
             data: this.dataOut,
             fill: true,
             label: 'Data Out',
             pointRadius: this.pointRadius
           },
           {
-            backgroundColor: 'rgb(14, 204, 95)',
+            backgroundColor: 'rgb(110,224,159)',
             borderColor: 'rgb(14, 204, 95)',
             data: this.dataIn,
             fill: true,
@@ -73,6 +72,11 @@ export default {
             interaction: {
               mode: 'index',
               intersect: false,
+              callbacks: {
+                label: (tooltipItem) => {
+                  return tooltipItem.raw.toFixed(2) + ` ${this.unit}`
+                }
+              }
             }
           },
           hover: {
@@ -110,11 +114,19 @@ export default {
     },
     yLabel: {
       type: String,
-      default: 'Data (KB)'
+      default: 'KB'
+    }
+  },
+  computed: {
+    unit() {
+      return this.yLabel.substring(6, 8)
     }
   }
 }
 </script>
 
 <style scoped>
+.tile {
+  @apply flex-1 p-12 md:p-24 text-sm text-gray-300 bg-white rounded;
+}
 </style>

--- a/src/components/NodeChartRequests.vue
+++ b/src/components/NodeChartRequests.vue
@@ -6,7 +6,6 @@
         :chart-options="chartOptions"
         :chart-data="chartData"
         :chart-id="'NodeRequestsChart'"
-        :width="width"
         :height="height"
       />
     </div>
@@ -66,7 +65,7 @@ export default {
           tooltip: {
             interaction: {
               mode: 'index',
-              intersect: false,
+              intersect: false
             }
           }
         }
@@ -99,4 +98,7 @@ export default {
 </script>
 
 <style scoped>
+.tile {
+  @apply flex-1 p-12 md:p-24 text-sm text-gray-300 bg-white rounded;
+}
 </style>

--- a/src/components/NodeChartTimeToggle.vue
+++ b/src/components/NodeChartTimeToggle.vue
@@ -31,17 +31,22 @@ export default {
 <style scoped>
 .toggle-wrapper {
   @apply flex items-center mb-15 justify-end rounded border border-solid;
-  border-color: rgb(14, 204, 95)
+  border-color: #afafaf
 }
 
 .toggle {
-  @apply text-gray p-5 w-80 text-center cursor-pointer border border-solid;
-  border-color: rgb(14, 204, 95)
+  @apply text-gray p-5 w-80 text-center text-xs cursor-pointer border-solid uppercase;
+  border-color: #afafaf
+}
+
+.toggle:nth-child(2) {
+  border-right: solid 1px;
+  border-left: solid 1px;
+  border-color: #afafaf
 }
 
 .toggle.selected {
   @apply text-white;
   background-color: rgb(14, 204, 95);
 }
-
 </style>


### PR DESCRIPTION
Few tweaks to chart designs:
- White panel background
- Light grey outline for period selector, plus reduced font size and made all uppercase
- Softer red on Data Out series 
- Gave Data In/Out charts a less solid fill colour (let me know thoughts on this)
- Added units to Availability and Data In/Out charts tooltips (% and KB/MB)

![image](https://user-images.githubusercontent.com/74154911/164467956-031e4ab0-038f-4474-a8b9-f3380cdde97c.png)
