### PR TITLE
fix: replace safari unsupported regex with alternative logic

### DIFF
--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -32,10 +32,11 @@ export default {
   ],
   computed: {
     isAscending() {
-      // check if expression is present is sorting query, but not preceded by a hyphen
-      // also, for multi-word expressions, check no word is preceded by hyphen
-      const regex = new RegExp('(?<!-)' + this.sortParam.replace(',', ',(?<!-)'))
-      return regex.test(this.sortQuery)
+       if (!this.isDescending) {
+        const regex = new RegExp(this.sortParam)
+        return regex.test(this.sortQuery)
+      }
+      else return false
     },
     isDescending() {
       const regex = new RegExp(`-${this.sortParam.replace(',', ',-')}`)


### PR DESCRIPTION
Anny, please test in safari (I don't have it) just to be sure, but I imagine this has fixed the issue - https://github.com/edge/explorer/issues/157