### PR TITLE
Feature/active stakes

### DIFF
--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -2,16 +2,19 @@
   <table>
     <thead class="hidden lg:table-header-group">
       <tr v-if="sortable">
-        <TableHeader width="16%" header="Address" :sortQuery="sortQuery"
+        <TableHeader :width="parentNode ? '30%' : '16%'"
+          header="Address" :sortQuery="sortQuery"
           sortParam="node.address" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <!-- currently no sorting on gateway and stargate columns as stargate address isn't contained in a host node's data -->
-        <th width="15%">Gateway</th>
-        <th width="15%">Stargate</th>
-        <TableHeader width="8%" header="Type" :sortQuery="sortQuery"
+        <th v-if="!parentNode" width="15%">Gateway</th>
+        <th v-if="!parentNode" width="15%">Stargate</th>
+        <TableHeader width="8%"
+          header="Type" :sortQuery="sortQuery"
           sortParam="node.type" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
-        <TableHeader width="20%" header="Location" :sortQuery="sortQuery"
+        <TableHeader :width="parentNode ? '30%' : '20%'"
+          header="Location" :sortQuery="sortQuery"
           sortParam="node.geo.country,node.geo.city" :onSortingUpdate="updateSorting" :sortAscFirst="true"
         />
         <TableHeader width="98" header="Availability" :sortQuery="sortQuery"
@@ -38,6 +41,7 @@
     <tbody v-if="sessions.length">
       <NodesTableItem
         v-for="item in sessions"
+        :parentNode="parentNode"
         :key="item.id"
         :item="item"
       />
@@ -83,6 +87,7 @@ export default {
     'hideOfflineNodes',
     'limit',
     'page',
+    'parentNode',
     'receiveMetadata',
     'sortable'
   ],
@@ -114,6 +119,7 @@ export default {
         page: this.page,
         sort: sortQuery
       }
+      if (this.parentNode) options.parent = this.parentNode
       if (this.hideOfflineNodes) options.hideOffline = 1
       const sessionsData = await index.session.sessions(
         process.env.VUE_APP_INDEX_API_URL,

--- a/src/components/NodesTableItem.vue
+++ b/src/components/NodesTableItem.vue
@@ -1,14 +1,14 @@
 <template>
   <tr>
     <td data-title="Address:" :title="item.node.address">
-      <router-link :to="addressRoute">
-        <span class="monospace lg:inline-block">
+      <router-link :to="addressRoute" class="max-w-max">
+        <span class="monospace max-w-max lg:inline-block">
           {{ item.node.address }}
         </span>
       </router-link>
     </td>
 
-    <td data-title="Gateway:" :title="item.node.gateway">
+    <td v-if="!parentNode" data-title="Gateway:" :title="item.node.gateway">
       <router-link v-if="isOnline && item.node.gateway" :to="gatewayRoute">
         <span class="monospace lg:inline-block">
           {{ item.node.gateway }}
@@ -19,7 +19,7 @@
       </span>
     </td>
 
-    <td data-title="Stargate:" :title="item.node.stargate">
+    <td v-if="!parentNode" data-title="Stargate:" :title="item.node.stargate">
       <router-link v-if="isOnline && item.node.stargate" :to="stargateRoute">
         <span class="monospace lg:inline-block">
           {{ item.node.stargate }}
@@ -73,7 +73,7 @@ import moment from 'moment'
 
 export default {
   name: 'NodesTableItem',
-  props: ['item'],
+  props: ['item', 'parentNode'],
   components: {
     ClockIcon,
     StatusOfflineIcon,

--- a/src/views/Nodes.vue
+++ b/src/views/Nodes.vue
@@ -10,6 +10,24 @@
             <NodeOverview :session="session" />
             <NodeSummary :session="session" />
           </div>
+          <div v-if="isGateway || isStargate" class="mb-35">
+            <h3>Connected {{ isGateway ? 'Hosts' : 'Gateways'}}</h3>
+            <NodesTable
+              :hideOfflineNodes="hideOfflineNodes"
+              :limit="limit"
+              :receiveMetadata="onSessionsUpdate"
+              :page="currentPage"
+              :parentNode="session.node.address"
+              :sortable="true"
+            />
+            <Pagination
+              v-if="metadata.totalCount > limit"
+              baseRoute="Node"
+              :currentPage="currentPage"
+              :limit="limit"
+              :totalCount="metadata.totalCount"
+            />
+          </div>
           <NodeChartTimeToggle :period="chartPeriod" :onPeriodUpdate="updateChartPeriod" />
           <div v-if="session.node.type !== 'host'" class="row full mb-25">
             <NodeChartAvailability
@@ -119,7 +137,6 @@ export default {
   },
   data: function () {
     return {
-      limit: 20,
       loading: false,
       metadata: { totalCount: 0 },
       session: null,
@@ -208,8 +225,17 @@ export default {
     isMdView() {
       return window.innerWidth >= 640 && window.innerWidth < 1000
     },
+    isGateway() {
+      return this.session && this.session.node.type === 'gateway'
+    },
+    isStargate() {
+      return this.session && this.session.node.type === 'stargate'
+    },
     lastPage() {
       return Math.max(1, Math.ceil(this.metadata.totalCount / this.limit))
+    },
+    limit() {
+      return this.address ? 5 : 30
     },
     maxUptime() {
       if (this.chartPeriod === 'day') return 3600 * 1000

--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -29,7 +29,13 @@
           </div>
           <div class="mt-20">
             <h3>Wallet Stakes</h3>
-            <StakesTable 
+            <div class="checkbox-container" @click="updateHideReleasedStakes" >
+              <label>Hide Released Stakes</label>
+              <input type="checkbox" :checked="hideReleasedStakes" />
+              <span class="checkmark"></span>
+            </div>
+            <StakesTable
+              :hideReleasedStakes="hideReleasedStakes"
               :limit="stakesLimit"
               :receiveMetadata="onStakesUpdate"
               :page="stakesCurrentPage"
@@ -135,6 +141,9 @@ export default {
     currentPage() {
       return Math.max(1, parseInt(this.$route.query.page) || 1)
     },
+    hideReleasedStakes() {
+      return this.$route.query.hideReleased === '1' || false
+    },
     lastPage() {
       return Math.max(1, Math.ceil(this.metadata.totalCount / this.limit))
     },
@@ -194,6 +203,12 @@ export default {
     },
     sliceString(string, symbols) {
       return string.length > symbols ? `${string.slice(0, symbols)}…` : string;
+    },
+    updateHideReleasedStakes() {
+      console.log('test')
+      const hideReleased = !this.hideReleasedStakes ? 1 : undefined
+      const query = { ...this.$route.query, hideReleased }
+      this.$router.replace({ query })
     }
   },
   watch: {
@@ -223,8 +238,73 @@ export default {
 }
 </script>
 <style scoped>
-  .row {
-    @apply grid items-start grid-cols-1 gap-24;
-    @apply lg:grid-cols-2;
-  }
+.row {
+  @apply grid items-start grid-cols-1 gap-24;
+  @apply lg:grid-cols-2;
+}
+
+.checkbox-container {
+@apply flex items-center mb-10 justify-end;
+cursor: pointer;
+-webkit-user-select: none;
+-moz-user-select: none;
+-ms-user-select: none;
+user-select: none;
+}
+
+.checkbox-container label {
+@apply cursor-pointer mr-5 mb-0;
+}
+
+.checkbox-container input {
+opacity: 0;
+height: 0;
+width: 0;
+}
+
+/* Create custom checkbox */
+.checkmark {
+@apply cursor-pointer mr-5 mb-0;
+position: relative;
+height: 13px;
+width: 13px;
+border: solid 1px #787878;
+border-radius: 3px;
+}
+
+/* On mouse-over, add grey background color */
+.checkbox-container:hover input ~ .checkmark {
+border-color: rgb(70, 70, 70);
+}
+
+/* When checkbox is checked, add green background */
+.checkbox-container input:checked ~ .checkmark {
+background-color: rgb(14,204,95);
+border: none;
+}
+
+/* Create checkmark (hidden when not checked) */
+.checkmark:after {
+content: "";
+position: absolute;
+display: none;
+}
+
+/* Show checkmark when checked */
+.checkbox-container input:checked ~ .checkmark:after {
+display: block;
+}
+
+/* Style for checkmark */
+.checkbox-container .checkmark:after {
+left: 4px;
+top: 1px;
+width: 5px;
+height: 9px;
+border: solid white;
+border-width: 0 2px 2px 0;
+-webkit-transform: rotate(45deg);
+-ms-transform: rotate(45deg);
+transform: rotate(45deg);
+}
 </style>


### PR DESCRIPTION
Actually a joint-feature branch as I have included both active stakes count and sessions by parent node.

This goes hand-in-hand with https://github.com/edge/index/pull/160

Active stakes count - wallet page now shows the active stakes count rather than total (which includes released stakes). Also a "hide released stakes" toggle has been added to stakes table on wallet page

Sessions by parent node - if you view a stargate or gateway page, you will now see the child nodes in a table (gws on sg page, hosts on gw page). Limited to 5 (with pagination) to not overload the page with info. I have also removed the gateway/stargate columns of the table here as it's not a necessary column since all the data is the same. 